### PR TITLE
Compiler N/RVO

### DIFF
--- a/include/sequence.hpp
+++ b/include/sequence.hpp
@@ -115,10 +115,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         Sequence() {}
-#ifdef __OPT_COPY__
-        Sequence(const Sequence &); // Not emplemented by design for RVO, NRVO enforcement
-        Sequence(Sequence &&);      // Not emplemented by design for RVO, NRVO enforcement
-#endif
+        Sequence(const Sequence &) {}
+        Sequence(Sequence &&) {}     
+
         template <typename... Arg>
         Sequence(const Arg &...args)
             : data_{args...}
@@ -247,10 +246,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         Sequence() : length_{0} {}
-#ifdef __OPT_COPY__
-        Sequence(const Sequence &); // Not emplemented by design for RVO, NRVO enforcement
-        Sequence(Sequence &&);      // Not emplemented by design for RVO, NRVO enforcement
-#endif
+        Sequence(const Sequence &) {}
+        Sequence(Sequence &&) {}
+        
         template <typename... Arg>
         Sequence(const Arg &...args)
             : data_{args...},
@@ -403,10 +401,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         Sequence() : data_{nullptr}, length_{0}, capacity_{0} {}
-#ifdef __OPT_COPY__
-        Sequence(const Sequence &); // Not emplemented by design for RVO, NRVO enforcement
-        Sequence(Sequence &&);      // Not emplemented by design for RVO, NRVO enforcement
-#else
+        // Sequence(const Sequence &) {}
+        // Sequence(Sequence &&) {}     
+
         Sequence(const Sequence &other)
             : data_{new A[other.capacity()]}, length_{other.size()}, capacity_{other.capacity()}
         {
@@ -420,7 +417,7 @@ namespace efp
         {
             other.data_ = nullptr;
         };
-#endif
+
         template <typename... Args>
         Sequence(const Args &...args)
             : data_{new A[sizeof...(args)]},
@@ -607,10 +604,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         SequenceView() : data_{nullptr} {}
-#ifdef __OPT_COPY__
-        SequenceView(const SequenceView &); // Not emplemented by design for RVO, NRVO enforcement
-        SequenceView(SequenceView &&);      // Not emplemented by design for RVO, NRVO enforcement
-#endif
+        // SequenceView(const SequenceView &) {}
+        // SequenceView(SequenceView &&) {}    
+        
         SequenceView(A *data)
             : data_{data}
         {
@@ -730,10 +726,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         SequenceView() : data_{nullptr}, length_{0} {}
-#ifdef __OPT_COPY__
-        SequenceView(const SequenceView &); // Not emplemented by design for RVO, NRVO enforcement
-        SequenceView(SequenceView &&);      // Not emplemented by design for RVO, NRVO enforcement
-#endif
+        // SequenceView(const SequenceView &) {}
+        // SequenceView(SequenceView &&) {}   
+        
         SequenceView(A *data) : data_{data}
         {
         }
@@ -862,10 +857,9 @@ namespace efp
         static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
         SequenceView() : data_{nullptr}, length_{0}, capacity_{0} {}
-#ifdef __OPT_COPY__
-        SequenceView(const SequenceView &); // Not emplemented by design for RVO, NRVO enforcement
-        SequenceView(SequenceView &&);      // Not emplemented by design for RVO, NRVO enforcement
-#endif
+        // SequenceView(const SequenceView &) {}
+        // SequenceView(SequenceView &&) {}    
+        
         SequenceView(A *data) : data_{data}, length_{0}, capacity_{0}
         {
         }

--- a/test/sequence_test.hpp
+++ b/test/sequence_test.hpp
@@ -74,22 +74,24 @@ TEST_CASE("crtp sequence init")
 //         CHECK(b.capacity() == 3);
 //     }
 // }
+Array<int, 3> *array_nrvo_p = nullptr;
 
-// Array<int, 3> array_rvo()
-// {
-//     return Array<int, 3>{1, 2, 3};
-// };
+Array<int, 3> array_rvo()
+{
+    return Array<int, 3>{1, 2, 3};
+};
 
-// Array<int, 3> array_nrvo()
-// {
-//     Array<int, 3> result{0, 0, 0};
+Array<int, 3> array_nrvo()
+{
+    Array<int, 3> result{0, 0, 0};
 
-//     result[0] = 1;
-//     result[1] = 2;
-//     result[2] = 3;
+    result[0] = 1;
+    result[1] = 2;
+    result[2] = 3;
+    array_nrvo_p = &result;
 
-//     return result;
-// };
+    return result;
+};
 
 // ArrVec<int, 3> array_vector_rvo()
 // {
@@ -123,13 +125,15 @@ TEST_CASE("crtp sequence init")
 //     return result;
 // };
 
-// TEST_CASE("copy elision")
-// {
-//     SECTION("Array")
-//     {
-//         CHECK(Array<int, 3>{1, 2, 3} == array_rvo());
-//         CHECK(Array<int, 3>{1, 2, 3} == array_nrvo());
-//     }
+TEST_CASE("copy elision")
+{
+    SECTION("Array")
+    {
+        Array<int, 3> na = array_nrvo();
+
+        CHECK(Array<int, 3>{1, 2, 3} == array_rvo());
+        CHECK(&na == array_nrvo_p);
+    }
 
 //     SECTION("ArrVec")
 //     {
@@ -142,7 +146,7 @@ TEST_CASE("crtp sequence init")
 //         CHECK(Vector<int>{1, 2, 3} == vector_rvo());
 //         CHECK(Vector<int>{1, 2, 3} == vector_nrvo());
 //     }
-// }
+}
 
 // TEST_CASE("assignment")
 // {

--- a/test/sequence_test.hpp
+++ b/test/sequence_test.hpp
@@ -75,6 +75,8 @@ TEST_CASE("crtp sequence init")
 //     }
 // }
 Array<int, 3> *array_nrvo_p = nullptr;
+ArrVec<int, 3> *arrvec_nrvo_p = nullptr;
+Vector<int> *vector_nrvo_p = nullptr;
 
 Array<int, 3> array_rvo()
 {
@@ -93,37 +95,39 @@ Array<int, 3> array_nrvo()
     return result;
 };
 
-// ArrVec<int, 3> array_vector_rvo()
-// {
-//     return ArrVec<int, 3>{1, 2, 3};
-// };
+ArrVec<int, 3> array_vector_rvo()
+{
+    return ArrVec<int, 3>{1, 2, 3};
+};
 
-// ArrVec<int, 3> array_vector_nrvo()
-// {
-//     ArrVec<int, 3> result{0, 0, 0};
+ArrVec<int, 3> array_vector_nrvo()
+{
+    ArrVec<int, 3> result{0, 0, 0};
 
-//     result[0] = 1;
-//     result[1] = 2;
-//     result[2] = 3;
+    result[0] = 1;
+    result[1] = 2;
+    result[2] = 3;
+    arrvec_nrvo_p = &result;
 
-//     return result;
-// };
+    return result;
+};
 
-// Vector<int> vector_rvo()
-// {
-//     return Vector<int>{1, 2, 3};
-// };
+Vector<int> vector_rvo()
+{
+    return Vector<int>{1, 2, 3};
+};
 
-// Vector<int> vector_nrvo()
-// {
-//     Vector<int> result{0, 0, 0};
+Vector<int> vector_nrvo()
+{
+    Vector<int> result{0, 0, 0};
 
-//     result[0] = 1;
-//     result[1] = 2;
-//     result[2] = 3;
+    result[0] = 1;
+    result[1] = 2;
+    result[2] = 3;
+    vector_nrvo_p = &result;
 
-//     return result;
-// };
+    return result;
+};
 
 TEST_CASE("copy elision")
 {
@@ -131,21 +135,25 @@ TEST_CASE("copy elision")
     {
         Array<int, 3> na = array_nrvo();
 
-        CHECK(Array<int, 3>{1, 2, 3} == array_rvo());
+        // CHECK(Array<int, 3>{1, 2, 3} == array_rvo());
         CHECK(&na == array_nrvo_p);
     }
 
-//     SECTION("ArrVec")
-//     {
-//         CHECK(ArrVec<int, 3>{1, 2, 3} == array_vector_rvo());
-//         CHECK(ArrVec<int, 3>{1, 2, 3} == array_vector_nrvo());
-//     }
+    SECTION("ArrVec")
+    {
+        ArrVec<int, 3> na = array_vector_nrvo();
 
-//     SECTION("Vector")
-//     {
-//         CHECK(Vector<int>{1, 2, 3} == vector_rvo());
-//         CHECK(Vector<int>{1, 2, 3} == vector_nrvo());
-//     }
+        // CHECK(ArrVec<int, 3>{1, 2, 3} == array_vector_rvo());
+        CHECK(&na == arrvec_nrvo_p);
+    }
+
+    SECTION("Vector")
+    {
+        Vector<int> na = vector_nrvo();
+
+        // CHECK(Vector<int>{1, 2, 3} == vector_rvo());
+        CHECK(&na == vector_nrvo_p);
+    }
 }
 
 // TEST_CASE("assignment")


### PR DESCRIPTION
From: https://en.wikipedia.org/wiki/Copy_elision

"RVO is allowed to change the observable behaviour of the resulting program by the C++ standard."

"The term return value optimization refers to a special clause in the C++ standard that goes even further than the "as-if" rule: an implementation may omit a copy operation resulting from a return statement, even if the copy constructor has side effects."

This optimization was observed on 
GCC 11.4.0 aarch64-linux-gnu
GCC 11.4.0 x86_64-linux-gnu
Clang 15.0.0 arm64-apple-darwin23.1.0
