### PR TITLE
Refactor/sequence view

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@ It is a general-purpose library. The usage of no-STL, resource-tight embedded ap
 ### Higher-Order Functions
 EFP supports major higher-order functions including `for_each`, `map`, `filter`, `foldl`, `foldr`, `from_function`, `for_index`, `for_each_with_index`, `cartesian_for_each`, `map_with_index`, `cartesian_map` and many more.
 
-### Zero-Copy Sequence Types
-Copying sequence is often an expensive operation yet does not necessary. Move semantic, size_troduced in C++ 11 somewhat eases the problem. However, the move helps little about stack sequence types like `std::array`, since moving such types is essentially a series of element-wise moves which is often no better than an element-wise copy.
-
-There is a better option, copy-elision (Return Value Optimization and Named Return Value Optimization). It makes returning heavy data free. Unfortunately, copy-elision is not guaranteed but at the compiler's discretion. (Since, C++ 17 some of them are guaranteed.)
-
-EFP offers zero-copy, guaranteed copy-elision (RVO, NRVO) sequence type as solutions to the issue; `efp::Sequence`, or `efp::Array`, `efp::ArrVec`, `efp::Vector` as aliased name. Copy-elision of these types is guaranteed regardless of compiler and C++ standards. To be exact, these types could be copy-assigned but not copy-constructed. These types are also used as the default output types of mixed-type, n-ary operations.
+### Contegious Sequence Types
+EFP offeres no-STL contegious sequence type `efp::Sequence` and `efp::SequenceView`, an immutable conteguous view of a sequence.
 
 ### Compile-Time Polymorphism
 HOFs of EFP accept `efp::Sequence` as sequence arguments. APIs are generic on these types, which means there is (almost)no need to care about sequence container type.  

--- a/include/enum_type.hpp
+++ b/include/enum_type.hpp
@@ -90,7 +90,7 @@ namespace efp
         return (power >= n) ? power : power_2_ceiling(n, power * 2);
     }
 
-    template <int n, typename... As>
+    template <size_t n, typename... As>
     struct Match
     {
     };
@@ -99,7 +99,7 @@ namespace efp
     class Enum
     {
     public:
-        template <int n, typename... Bs>
+        template <size_t n, typename... Bs>
         friend struct Match;
 
         template <typename A>

--- a/include/prelude.hpp
+++ b/include/prelude.hpp
@@ -260,8 +260,8 @@ namespace efp
     {
     };
 
-    template <int n, typename F>
-    struct FromFunctionReturnImpl<Int<n>, F>
+    template <size_t n, typename F>
+    struct FromFunctionReturnImpl<Size<n>, F>
     {
         using Type = Sequence<CallReturn<F, int>, n, n>;
     };
@@ -599,8 +599,8 @@ namespace efp
     {
     };
 
-    template <int n, typename A, bool is_const>
-    struct TakeReturnImpl<Int<n>, A, is_const>
+    template <size_t n, typename A, bool is_const>
+    struct TakeReturnImpl<Size<n>, A, is_const>
     {
         using Type = Conditional<
             IsStaticLength<A>::value,
@@ -662,8 +662,8 @@ namespace efp
     {
     };
 
-    template <int n, typename A, bool is_const>
-    struct DropReturnImpl<Int<n>, A, is_const>
+    template <size_t n, typename A, bool is_const>
+    struct DropReturnImpl<Size<n>, A, is_const>
     {
         using Type = Conditional<
             IsStaticLength<A>::value,

--- a/include/prelude.hpp
+++ b/include/prelude.hpp
@@ -483,22 +483,42 @@ namespace efp
 
     // tail
     // ! Partial function. Application on empty list is abortion.
+    // template <typename A>
+    // auto tail(const Seq<A> &as)
+    //     -> TailReturn<A, true>
+    // {
+    //     TailReturn<A, true> result{data(as) + 1};
+
+    //     if (A::ct_len == dyn)
+    //     {
+    //         const auto as_length = length(as);
+    //         if (as_length == 0)
+    //         {
+    //             abort();
+    //         }
+
+    //         result.resize(as_length - 1);
+    //     }
+
+    //     return result;
+    // }
+
     template <typename A>
     auto tail(const Seq<A> &as)
         -> TailReturn<A, true>
     {
-        TailReturn<A, true> result{data(as) + 1};
+        TailReturn<A, true> result{data(as) + 1, length(as) - Size<1>{}};
 
-        if (A::ct_len == dyn)
-        {
-            const auto as_length = length(as);
-            if (as_length == 0)
-            {
-                abort();
-            }
+        // if (A::ct_len == dyn)
+        // {
+        //     const auto as_length = length(as);
+        //     if (as_length == 0)
+        //     {
+        //         abort();
+        //     }
 
-            result.resize(as_length - 1);
-        }
+        //     result.resize(as_length - 1);
+        // }
 
         return result;
     }
@@ -507,18 +527,18 @@ namespace efp
     auto tail(Seq<A> &as)
         -> TailReturn<A, false>
     {
-        TailReturn<A, false> result{data(as) + 1};
+        TailReturn<A, false> result{data(as) + 1, length(as) - Size<1>{}};
 
-        if (A::ct_len == dyn)
-        {
-            const auto as_length = length(as);
-            if (as_length == 0)
-            {
-                abort();
-            }
+        // if (A::ct_len == dyn)
+        // {
+        //     const auto as_length = length(as);
+        //     if (as_length == 0)
+        //     {
+        //         abort();
+        //     }
 
-            result.resize(as_length - 1);
-        }
+        //     result.resize(as_length - 1);
+        // }
 
         return result;
     }
@@ -538,18 +558,18 @@ namespace efp
     auto init(const Seq<A> &as)
         -> InitReturn<A, true>
     {
-        InitReturn<A, true> result{data(as)};
+        InitReturn<A, true> result{data(as), length(as) - Size<1>{}};
 
-        if (A::ct_len == dyn)
-        {
-            const auto as_length = length(as);
-            if (as_length == 0)
-            {
-                abort();
-            }
+        // if (A::ct_len == dyn)
+        // {
+        //     const auto as_length = length(as);
+        //     if (as_length == 0)
+        //     {
+        //         abort();
+        //     }
 
-            result.resize(as_length - 1);
-        }
+        //     result.resize(as_length - 1);
+        // }
 
         return result;
     }
@@ -559,18 +579,18 @@ namespace efp
     auto init(Seq<A> &as)
         -> InitReturn<A, false>
     {
-        InitReturn<A, false> result{data(as)};
+        InitReturn<A, false> result{data(as), length(as) - Size<1>{}};
 
-        if (A::ct_len == dyn)
-        {
-            const auto as_length = length(as);
-            if (as_length == 0)
-            {
-                abort();
-            }
+        // if (A::ct_len == dyn)
+        // {
+        //     const auto as_length = length(as);
+        //     if (as_length == 0)
+        //     {
+        //         abort();
+        //     }
 
-            result.resize(as_length - 1);
-        }
+        //     result.resize(as_length - 1);
+        // }
 
         return result;
     }

--- a/include/sequence.hpp
+++ b/include/sequence.hpp
@@ -846,32 +846,16 @@ namespace efp
 
         // static_assert(ct_len >= -1, "ct_length must greater or equal than -1.");
 
-        // SequenceView() : data_{nullptr} {}
-        // // SequenceView(const SequenceView &) {}
-        // // SequenceView(SequenceView &&) {}
-
-        // SequenceView(A *data)
-        //     : data_{data}
-        // {
-        // }
-
-        // SequenceView &operator=(const SequenceView &other)
-        // {
-        //     if (this != &other)
-        //     {
-        //         data_ = other.data_;
-        //     }
-        //     return *this;
-        // }
-
-        // SequenceView assign_impl(const SequenceView &other)
-        // {
-        //     if (this != &other)
-        //     {
-        //         data_ = other.data_;
-        //     }
-        //     return *this;
-        // }
+        // ! length will not be used
+        explicit SequenceView(A *data, size_t length)
+            : data_(data)
+        {
+            // Ensure that data is not nullptr for a non-empty view.
+            if (ct_len > 0 && data_ == nullptr)
+            {
+                abort();
+            }
+        }
 
         explicit SequenceView(A *data)
             : data_(data)
@@ -887,11 +871,11 @@ namespace efp
         // copy assignment operator, move constructor, or move assignment operator,
         // you should define all of them. Here, the default behavior is size_tended.
 
-        SequenceView(const SequenceView &) = default;
-        SequenceView(SequenceView &&) noexcept = default;
-        SequenceView &operator=(const SequenceView &) = default;
-        SequenceView &operator=(SequenceView &&) noexcept = default;
-        ~SequenceView() = default;
+        // SequenceView(const SequenceView &) = default;
+        // SequenceView(SequenceView &&) noexcept = default;
+        // SequenceView &operator=(const SequenceView &) = default;
+        // SequenceView &operator=(SequenceView &&) noexcept = default;
+        // ~SequenceView() = default;
 
         A &operator[](int index)
         {
@@ -988,17 +972,27 @@ namespace efp
         // static_assert(ct_len >= -1, "ct_length must greater or equal than -1.");
         // static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
-        SequenceView() : data_{nullptr}, size_{0} {}
+        // SequenceView() : data_{nullptr}, size_{0} {}
         // SequenceView(const SequenceView &) {}
         // SequenceView(SequenceView &&) {}
+
+        explicit SequenceView(A *data, size_t size)
+            : data_(data), size_(size)
+        {
+            // Ensure that data is not nullptr for a non-empty view.
+            if (size > 0 && data_ == nullptr)
+            {
+                abort();
+            }
+        }
 
         SequenceView(A *data) : data_{data}
         {
         }
-        SequenceView(A *data, const int length)
-            : data_{data}, size_{length}
-        {
-        }
+        // SequenceView(A *data, const int length)
+        //     : data_{data}, size_{length}
+        // {
+        // }
 
         SequenceView &operator=(const SequenceView &other)
         {
@@ -1010,15 +1004,15 @@ namespace efp
             return *this;
         }
 
-        SequenceView assign_impl(const SequenceView &other)
-        {
-            if (this != &other)
-            {
-                data_ = other.data_;
-                size_ = other.size_;
-            }
-            return *this;
-        }
+        // SequenceView assign_impl(const SequenceView &other)
+        // {
+        //     if (this != &other)
+        //     {
+        //         data_ = other.data_;
+        //         size_ = other.size_;
+        //     }
+        //     return *this;
+        // }
 
         A &operator[](int index)
         {
@@ -1116,18 +1110,29 @@ namespace efp
         static constexpr int ct_len = dyn;
         static constexpr int ct_cap = dyn;
 
-        static_assert(ct_len >= -1, "ct_length must greater or equal than -1.");
-        static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
+        // static_assert(ct_len >= -1, "ct_length must greater or equal than -1.");
+        // static_assert(ct_cap >= -1, "ct_capacity must greater or equal than -1.");
 
-        SequenceView() : data_{nullptr}, size_{0}, capacity_{0} {}
+        // SequenceView() : data_{nullptr}, size_{0}, capacity_{0} {}
         // SequenceView(const SequenceView &) {}
         // SequenceView(SequenceView &&) {}
 
-        SequenceView(A *data) : data_{data}, size_{0}, capacity_{0}
+        explicit SequenceView(A *data, size_t size)
+            : data_(data), size_(size), capacity_(size)
         {
+            // Ensure that data is not nullptr for a non-empty view.
+            if (size > 0 && data_ == nullptr)
+            {
+                abort();
+            }
         }
-        SequenceView(A *data, const int length, const int capacity)
-            : data_{data}, size_{length}, capacity_{capacity} {}
+
+        // SequenceView(A *data) : data_{data}, size_{0}, capacity_{0}
+        // {
+        // }
+
+        // SequenceView(A *data, const int length, const int capacity)
+        //     : data_{data}, size_{length}, capacity_{capacity} {}
 
         SequenceView &operator=(const SequenceView &other)
         {
@@ -1140,16 +1145,16 @@ namespace efp
             return *this;
         }
 
-        SequenceView assign_impl(const SequenceView &other)
-        {
-            if (this != &other)
-            {
-                data_ = other.data_;
-                size_ = other.size_;
-                capacity_ = other.capacity_;
-            }
-            return *this;
-        }
+        // SequenceView assign_impl(const SequenceView &other)
+        // {
+        //     if (this != &other)
+        //     {
+        //         data_ = other.data_;
+        //         size_ = other.size_;
+        //         capacity_ = other.capacity_;
+        //     }
+        //     return *this;
+        // }
 
         A &operator[](int index)
         {
@@ -1368,14 +1373,14 @@ namespace efp
 
     template <typename A>
     constexpr auto length(const Seq<A> &as)
-        -> EnableIf<A::ct_len != dyn, IntegralConst<int, A::ct_len>>
+        -> EnableIf<A::ct_len != dyn, IntegralConst<size_t, A::ct_len>>
     {
-        return IntegralConst<int, A::ct_len>{};
+        return IntegralConst<size_t, A::ct_len>{};
     }
 
     template <typename A>
     constexpr auto length(const Seq<A> &as)
-        -> EnableIf<A::ct_len == dyn, int>
+        -> EnableIf<A::ct_len == dyn, size_t>
     {
         return as.size();
     }

--- a/include/sfinae.hpp
+++ b/include/sfinae.hpp
@@ -380,6 +380,11 @@ namespace efp
     template <int n>
     using Int = IntegralConst<int, n>;
 
+    // Size
+
+    template <int n>
+    using Size = IntegralConst<size_t, n>;
+
     // IsSame
 
     template <typename A, typename B>
@@ -430,12 +435,12 @@ namespace efp
 
     // FindHelper
 
-    template <int n, template <class> class P, typename... Args>
+    template <size_t n, template <class> class P, typename... Args>
     struct FindHelper
     {
     };
 
-    template <int n, template <class> class P, typename Head, typename... Tail>
+    template <size_t n, template <class> class P, typename Head, typename... Tail>
     struct FindHelper<n, P, Head, Tail...>
         : Conditional<
               P<Head>::value,
@@ -578,7 +583,7 @@ namespace efp
 
     // MakeIndexSequenceImpl
 
-    template <int n, int... ns>
+    template <size_t n, int... ns>
     struct MakeIndexSequenceImpl
         : MakeIndexSequenceImpl<n - 1, n - 1, ns...>
     {

--- a/test/prelude_test.hpp
+++ b/test/prelude_test.hpp
@@ -157,7 +157,7 @@ TEST_CASE("from_function")
 
     SECTION("Array")
     {
-        CHECK(from_function(IntegralConst<int, 3>{}, plus_one) == Array<int, 3>{1, 2, 3});
+        CHECK(from_function(Size<3>{}, plus_one) == Array<int, 3>{1, 2, 3});
     }
 
     SECTION("Vector")
@@ -167,7 +167,7 @@ TEST_CASE("from_function")
 
     SECTION("template")
     {
-        CHECK(from_function(IntegralConst<int, 3>{}, id<int>) == Array<int, 3>{0, 1, 2});
+        CHECK(from_function(Size<3>{}, id<int>) == Array<int, 3>{0, 1, 2});
     }
 }
 
@@ -378,7 +378,7 @@ TEST_CASE("slice")
 {
     SECTION("static")
     {
-        const auto slice_ = slice(Int<1>{}, Int<3>{}, array_5);
+        const auto slice_ = slice(Size<1>{}, Size<3>{}, array_5);
         CHECK(length(slice_) == 2);
         CHECK(IsStaticLength<decltype(slice_)>::value);
         CHECK(slice_[0] == 2.);

--- a/test/prelude_test.hpp
+++ b/test/prelude_test.hpp
@@ -274,7 +274,7 @@ TEST_CASE("tail")
     {
         CHECK(tail(array_3) == ArrayView<const double, 2>{data(array_3) + 1});
         CHECK(tail(arrvec_3) == ArrVecView<const double, 2>{data(arrvec_3) + 1, 2});
-        CHECK(tail(vector_3) == VectorView<const double>{data(vector_3) + 1, 2, 2});
+        CHECK(tail(vector_3) == VectorView<const double>{data(vector_3) + 1, 2});
     }
 
     SECTION("non const")
@@ -285,7 +285,7 @@ TEST_CASE("tail")
 
         CHECK(tail(array) == ArrayView<double, 2>{data(array) + 1});
         CHECK(tail(arrvec) == ArrVecView<double, 2>{data(arrvec) + 1, 2});
-        CHECK(tail(vector) == VectorView<double>{data(vector) + 1, 2, 2});
+        CHECK(tail(vector) == VectorView<double>{data(vector) + 1, 2});
     }
 }
 
@@ -295,7 +295,7 @@ TEST_CASE("init")
     {
         CHECK(init(array_3) == ArrayView<const double, 2>{data(array_3)});
         CHECK(init(arrvec_3) == ArrVecView<const double, 2>{data(arrvec_3), 2});
-        CHECK(init(vector_3) == VectorView<const double>{data(vector_3), 2, 2});
+        CHECK(init(vector_3) == VectorView<const double>{data(vector_3), 2});
     }
 
     SECTION("non const")
@@ -306,7 +306,7 @@ TEST_CASE("init")
 
         CHECK(init(array) == ArrayView<double, 2>{data(array)});
         CHECK(init(arrvec) == ArrVecView<double, 2>{data(arrvec), 2});
-        CHECK(init(vector) == VectorView<double>{data(vector), 2, 2});
+        CHECK(init(vector) == VectorView<double>{data(vector), 2});
     }
 }
 
@@ -330,7 +330,7 @@ TEST_CASE("take")
 
     SECTION("array 1")
     {
-        const auto res = take(-1, array_3);
+        const auto res = take(0, array_3);
         CHECK(data(res) == data(array_3));
         CHECK(length(res) == 0);
     }
@@ -358,7 +358,8 @@ TEST_CASE("drop")
 
     SECTION("array 1")
     {
-        const auto res = drop(-1, array_3);
+        // ! do not put negative values
+        const auto res = drop(0, array_3);
         CHECK(data(res) == data(array_3));
         CHECK(length(res) == 3);
         CHECK(res[0] == 1.);
@@ -388,7 +389,7 @@ TEST_CASE("slice")
     SECTION("dynamic")
     {
         const auto slice_ = slice(1, 3, array_5);
-        CHECK(IsSame<decltype(length(slice_)), int>::value);
+        CHECK(IsSame<decltype(length(slice_)), size_t>::value);
         CHECK(!IsStaticLength<decltype(slice_)>::value);
         CHECK(slice_[0] == 2.);
         CHECK(slice_[1] == 3.);

--- a/test/scientific_test.hpp
+++ b/test/scientific_test.hpp
@@ -291,7 +291,7 @@ TEST_CASE("remove_dc")
 
     SECTION("Array")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
         auto ys_ref = map(f_ref, xs);
@@ -302,7 +302,7 @@ TEST_CASE("remove_dc")
 
     SECTION("std::array")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
         auto ys_ref = map(f_ref, xs);
@@ -313,7 +313,7 @@ TEST_CASE("remove_dc")
 
     SECTION("std::vector")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
         auto ys_ref = map(f_ref, xs);
@@ -337,7 +337,7 @@ TEST_CASE("linear_regression")
 
     SECTION("Array")
     {
-        auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
 
@@ -352,7 +352,7 @@ TEST_CASE("linear_regression")
     SECTION("Array")
     {
 
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
 
@@ -367,7 +367,7 @@ TEST_CASE("linear_regression")
     SECTION("std::array")
     {
 
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
 
@@ -381,7 +381,7 @@ TEST_CASE("linear_regression")
 
     SECTION("std::vector")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         auto ys = map(f, xs);
 
@@ -423,7 +423,7 @@ TEST_CASE("linear_regression_with_index")
 
     SECTION("std::array")
     {
-        auto ys = from_function(IntegralConst<int, n>{}, f);
+        auto ys = from_function(Size<n>{}, f);
 
         const auto tpl = linear_regression_with_index<double>(ys);
         const auto a_hat = get<0>(tpl);
@@ -475,7 +475,7 @@ TEST_CASE("detrend")
 
     SECTION("std::array")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         const auto ys1 = map(f1, xs);
         const auto ys2 = map(f2, xs);
@@ -492,7 +492,7 @@ TEST_CASE("detrend")
 
     SECTION("Vector")
     {
-        const auto xs = from_function(IntegralConst<int, n>{}, id<int>);
+        const auto xs = from_function(Size<n>{}, id<int>);
 
         const auto ys1 = map(f1, xs);
         const auto ys2 = map(f2, xs);

--- a/test/sequence_test.hpp
+++ b/test/sequence_test.hpp
@@ -460,7 +460,7 @@ TEST_CASE("VectorView")
 {
     SECTION("copy construction")
     {
-        VectorView<const double> view_1{data(array_3), 3, 3};
+        VectorView<const double> view_1{data(array_3), 3};
         auto view_2 = view_1;
         CHECK(view_1 == view_2);
     }

--- a/test/sfinae_test.hpp
+++ b/test/sfinae_test.hpp
@@ -10,13 +10,13 @@ using namespace efp;
 
 // TEST_CASE("bound_v")
 // {
-//     CHECK(bound_v(0, 2, IntegralConst<int, -1>{}) == 0);
-//     CHECK(bound_v(0, 2, IntegralConst<int, 1>{}) == 1);
-//     CHECK(bound_v(0, 2, IntegralConst<int, 3>{}) == 2);
-//     CHECK(bound_v(0, IntegralConst<int, 3>{}, -1) == 0);
+//     CHECK(bound_v(0, 2, IntegralConst<size_t, -1>{}) == 0);
+//     CHECK(bound_v(0, 2, IntegralConst<size_t, 1>{}) == 1);
+//     CHECK(bound_v(0, 2, IntegralConst<size_t, 3>{}) == 2);
+//     CHECK(bound_v(0, IntegralConst<size_t, 3>{}, -1) == 0);
 //     // ! issue
-//     // CHECK((-1 > IntegralConst<int, 3>{}) == true);
-//     // CHECK((-1 > IntegralConst<int, 3>{}) ? (IntegralConst<int, 3>{}) : ((-1 < 0) ? 0 : -1) == 0);
+//     // CHECK((-1 > IntegralConst<size_t, 3>{}) == true);
+//     // CHECK((-1 > IntegralConst<size_t, 3>{}) ? (IntegralConst<int, 3>{}) : ((-1 < 0) ? 0 : -1) == 0);
 // }
 
 TEST_CASE("all_v")

--- a/test/test_common.hpp
+++ b/test/test_common.hpp
@@ -22,8 +22,8 @@ const ArrayView<const double, 5> array_view_5{data(array_5)};
 const ArrVecView<const double, 3> arrvec_view_3{data(vector_3), 3};
 const ArrVecView<const double, 5> arrvec_view_5{data(vector_5), 5};
 
-const VectorView<const double> vector_view_3{data(vector_3), 3, 3};
-const VectorView<const double> vector_view_5{data(vector_5), 5, 5};
+const VectorView<const double> vector_view_3{data(vector_3), 3};
+const VectorView<const double> vector_view_5{data(vector_5), 5};
 
 const double c_array_3[3] = {1., 2., 3.};
 const double c_array_5[5] = {1., 2., 3., 4., 5.};


### PR DESCRIPTION
Refactoring SequenceViews could be constructed from a pointer to the data and length.
- Previous API was taking a pointer to the data and resizing afterward if the size was dynamic.
- Changed API will take data and length uniformly. 
- Since the length information is not necessary for the `ArrayView`, it will take `IntegralConstant<size_t, n>` or `Size<n>`.
- For convenience, the constructor for the `ArrayView` will have a default value of the length parameter.