### PR TITLE
Dev/efp ci issue 240219

### DIFF
--- a/include/efp/cpp_core.hpp
+++ b/include/efp/cpp_core.hpp
@@ -20,15 +20,22 @@
     #include <cstring>
 
 namespace efp {
-void* (*memcpy)(void* dest, const void* src, size_t size) = std::memcpy;
+// Use a function alias for clarity and avoid direct assignment to avoid potential confusion.
+inline void* _memcpy(void* dest, const void* src, size_t size) {
+    return std::memcpy(dest, src, size);
 }
+}  // namespace efp
 
 #else
 
 namespace efp {
-void* memcpy(void* dest, const void* src, size_t size) {
+// Custom memcpy implementation for freestanding environments.
+// Added extern "C" to ensure C linkage for compatibility with C libraries or code.
+extern "C" void* _memcpy(void* dest, const void* src, size_t size) {
+    auto* d = static_cast<char*>(dest);
+    const auto* s = static_cast<const char*>(src);
     for (size_t i = 0; i < size; ++i) {
-        static_cast<char*>(dest)[i] = static_cast<const char*>(src)[i];
+        d[i] = s[i];
     }
     return dest;
 }

--- a/include/efp/cpp_core.hpp
+++ b/include/efp/cpp_core.hpp
@@ -17,28 +17,28 @@
 
 #if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
 
-#include <cstring>
+    #include <cstring>
 
 namespace efp {
-    // Use a function alias for clarity and avoid direct assignment to avoid potential confusion.
-    inline void* _memcpy(void* dest, const void* src, size_t size) {
-        return std::memcpy(dest, src, size);
-    }
+// Use a function alias for clarity and avoid direct assignment to avoid potential confusion.
+inline void* _memcpy(void* dest, const void* src, size_t size) {
+    return std::memcpy(dest, src, size);
 }
+}  // namespace efp
 
 #else
 
 namespace efp {
-    // Custom memcpy implementation for freestanding environments.
-    // Added extern "C" to ensure C linkage for compatibility with C libraries or code.
-    extern "C" void* _memcpy(void* dest, const void* src, size_t size) {
-        auto* d = static_cast<char*>(dest);
-        const auto* s = static_cast<const char*>(src);
-        for (size_t i = 0; i < size; ++i) {
-            d[i] = s[i];
-        }
-        return dest;
+// Custom memcpy implementation for freestanding environments.
+// Added extern "C" to ensure C linkage for compatibility with C libraries or code.
+extern "C" void* _memcpy(void* dest, const void* src, size_t size) {
+    auto* d = static_cast<char*>(dest);
+    const auto* s = static_cast<const char*>(src);
+    for (size_t i = 0; i < size; ++i) {
+        d[i] = s[i];
     }
+    return dest;
+}
 }  // namespace efp
 
 #endif

--- a/include/efp/cpp_core.hpp
+++ b/include/efp/cpp_core.hpp
@@ -17,28 +17,28 @@
 
 #if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
 
-    #include <cstring>
+#include <cstring>
 
 namespace efp {
-// Use a function alias for clarity and avoid direct assignment to avoid potential confusion.
-inline void* _memcpy(void* dest, const void* src, size_t size) {
-    return std::memcpy(dest, src, size);
+    // Use a function alias for clarity and avoid direct assignment to avoid potential confusion.
+    inline void* _memcpy(void* dest, const void* src, size_t size) {
+        return std::memcpy(dest, src, size);
+    }
 }
-}  // namespace efp
 
 #else
 
 namespace efp {
-// Custom memcpy implementation for freestanding environments.
-// Added extern "C" to ensure C linkage for compatibility with C libraries or code.
-extern "C" void* _memcpy(void* dest, const void* src, size_t size) {
-    auto* d = static_cast<char*>(dest);
-    const auto* s = static_cast<const char*>(src);
-    for (size_t i = 0; i < size; ++i) {
-        d[i] = s[i];
+    // Custom memcpy implementation for freestanding environments.
+    // Added extern "C" to ensure C linkage for compatibility with C libraries or code.
+    extern "C" void* _memcpy(void* dest, const void* src, size_t size) {
+        auto* d = static_cast<char*>(dest);
+        const auto* s = static_cast<const char*>(src);
+        for (size_t i = 0; i < size; ++i) {
+            d[i] = s[i];
+        }
+        return dest;
     }
-    return dest;
-}
 }  // namespace efp
 
 #endif

--- a/include/efp/fmt/core.h
+++ b/include/efp/fmt/core.h
@@ -5,8 +5,8 @@
 //
 // For the license information refer to format.h.
 
-#ifndef FMT_CORE_H_
-#define FMT_CORE_H_
+#ifndef EFP_FMT_CORE_H_
+#define EFP_FMT_CORE_H_
 
 #include <cstddef>  // std::byte
 #include <cstdio>   // std::FILE
@@ -3283,4 +3283,4 @@ FMT_END_NAMESPACE
 #ifdef FMT_HEADER_ONLY
     #include "format.h"
 #endif
-#endif  // FMT_CORE_H_
+#endif  // EFP_FMT_CORE_H_

--- a/include/efp/fmt/core.h
+++ b/include/efp/fmt/core.h
@@ -21,230 +21,230 @@
 
 // todo local support
 // ! No local support
-#define FMT_STATIC_THOUSANDS_SEPARATOR
+#define EFP_FMT_STATIC_THOUSANDS_SEPARATOR
 
 // The fmt library version in the form major * 10000 + minor * 100 + patch.
-#define FMT_VERSION 100101
+#define EFP_FMT_VERSION 100101
 
 #if defined(__clang__) && !defined(__ibmxl__)
-    #define FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
+    #define EFP_FMT_CLANG_VERSION (__clang_major__ * 100 + __clang_minor__)
 #else
-    #define FMT_CLANG_VERSION 0
+    #define EFP_FMT_CLANG_VERSION 0
 #endif
 
 #if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER) && !defined(__NVCOMPILER)
-    #define FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
+    #define EFP_FMT_GCC_VERSION (__GNUC__ * 100 + __GNUC_MINOR__)
 #else
-    #define FMT_GCC_VERSION 0
+    #define EFP_FMT_GCC_VERSION 0
 #endif
 
-#ifndef FMT_GCC_PRAGMA
+#ifndef EFP_FMT_GCC_PRAGMA
     // Workaround _Pragma bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=59884.
-    #if FMT_GCC_VERSION >= 504
-        #define FMT_GCC_PRAGMA(arg) _Pragma(arg)
+    #if EFP_FMT_GCC_VERSION >= 504
+        #define EFP_FMT_GCC_PRAGMA(arg) _Pragma(arg)
     #else
-        #define FMT_GCC_PRAGMA(arg)
+        #define EFP_FMT_GCC_PRAGMA(arg)
     #endif
 #endif
 
 #ifdef __ICL
-    #define FMT_ICC_VERSION __ICL
+    #define EFP_FMT_ICC_VERSION __ICL
 #elif defined(__INTEL_COMPILER)
-    #define FMT_ICC_VERSION __INTEL_COMPILER
+    #define EFP_FMT_ICC_VERSION __INTEL_COMPILER
 #else
-    #define FMT_ICC_VERSION 0
+    #define EFP_FMT_ICC_VERSION 0
 #endif
 
 #ifdef _MSC_VER
-    #define FMT_MSC_VERSION _MSC_VER
-    #define FMT_MSC_WARNING(...) __pragma(warning(__VA_ARGS__))
+    #define EFP_FMT_MSC_VERSION _MSC_VER
+    #define EFP_FMT_MSC_WARNING(...) __pragma(warning(__VA_ARGS__))
 #else
-    #define FMT_MSC_VERSION 0
-    #define FMT_MSC_WARNING(...)
+    #define EFP_FMT_MSC_VERSION 0
+    #define EFP_FMT_MSC_WARNING(...)
 #endif
 
 #ifdef _MSVC_LANG
-    #define FMT_CPLUSPLUS _MSVC_LANG
+    #define EFP_FMT_CPLUSPLUS _MSVC_LANG
 #else
-    #define FMT_CPLUSPLUS __cplusplus
+    #define EFP_FMT_CPLUSPLUS __cplusplus
 #endif
 
 #ifdef __has_feature
-    #define FMT_HAS_FEATURE(x) __has_feature(x)
+    #define EFP_FMT_HAS_FEATURE(x) __has_feature(x)
 #else
-    #define FMT_HAS_FEATURE(x) 0
+    #define EFP_FMT_HAS_FEATURE(x) 0
 #endif
 
-#if defined(__has_include) || FMT_ICC_VERSION >= 1600 || FMT_MSC_VERSION > 1900
-    #define FMT_HAS_INCLUDE(x) __has_include(x)
+#if defined(__has_include) || EFP_FMT_ICC_VERSION >= 1600 || EFP_FMT_MSC_VERSION > 1900
+    #define EFP_FMT_HAS_INCLUDE(x) __has_include(x)
 #else
-    #define FMT_HAS_INCLUDE(x) 0
+    #define EFP_FMT_HAS_INCLUDE(x) 0
 #endif
 
 #ifdef __has_cpp_attribute
-    #define FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
+    #define EFP_FMT_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)
 #else
-    #define FMT_HAS_CPP_ATTRIBUTE(x) 0
+    #define EFP_FMT_HAS_CPP_ATTRIBUTE(x) 0
 #endif
 
-#define FMT_HAS_CPP14_ATTRIBUTE(attribute) \
-    (FMT_CPLUSPLUS >= 201402L && FMT_HAS_CPP_ATTRIBUTE(attribute))
+#define EFP_FMT_HAS_CPP14_ATTRIBUTE(attribute) \
+    (EFP_FMT_CPLUSPLUS >= 201402L && EFP_FMT_HAS_CPP_ATTRIBUTE(attribute))
 
-#define FMT_HAS_CPP17_ATTRIBUTE(attribute) \
-    (FMT_CPLUSPLUS >= 201703L && FMT_HAS_CPP_ATTRIBUTE(attribute))
+#define EFP_FMT_HAS_CPP17_ATTRIBUTE(attribute) \
+    (EFP_FMT_CPLUSPLUS >= 201703L && EFP_FMT_HAS_CPP_ATTRIBUTE(attribute))
 
 // Check if relaxed C++14 constexpr is supported.
 // GCC doesn't allow throw in constexpr until version 6 (bug 67371).
-#ifndef FMT_USE_CONSTEXPR
-    #if (FMT_HAS_FEATURE(cxx_relaxed_constexpr) || FMT_MSC_VERSION >= 1912 || (FMT_GCC_VERSION >= 600 && FMT_CPLUSPLUS >= 201402L)) \
-        && !FMT_ICC_VERSION && (!defined(__NVCC__) || FMT_CPLUSPLUS >= 202002L)
-        #define FMT_USE_CONSTEXPR 1
+#ifndef EFP_FMT_USE_CONSTEXPR
+    #if (EFP_FMT_HAS_FEATURE(cxx_relaxed_constexpr) || EFP_FMT_MSC_VERSION >= 1912 || (EFP_FMT_GCC_VERSION >= 600 && EFP_FMT_CPLUSPLUS >= 201402L)) \
+        && !EFP_FMT_ICC_VERSION && (!defined(__NVCC__) || EFP_FMT_CPLUSPLUS >= 202002L)
+        #define EFP_FMT_USE_CONSTEXPR 1
     #else
-        #define FMT_USE_CONSTEXPR 0
+        #define EFP_FMT_USE_CONSTEXPR 0
     #endif
 #endif
-#if FMT_USE_CONSTEXPR
-    #define FMT_CONSTEXPR constexpr
+#if EFP_FMT_USE_CONSTEXPR
+    #define EFP_FMT_CONSTEXPR constexpr
 #else
-    #define FMT_CONSTEXPR
+    #define EFP_FMT_CONSTEXPR
 #endif
 
-#if ((FMT_CPLUSPLUS >= 202002L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) \
-    || (FMT_CPLUSPLUS >= 201709L && FMT_GCC_VERSION >= 1002)
-    #define FMT_CONSTEXPR20 constexpr
+#if ((EFP_FMT_CPLUSPLUS >= 202002L) && (!defined(_GLIBCXX_RELEASE) || _GLIBCXX_RELEASE > 9)) \
+    || (EFP_FMT_CPLUSPLUS >= 201709L && EFP_FMT_GCC_VERSION >= 1002)
+    #define EFP_FMT_CONSTEXPR20 constexpr
 #else
-    #define FMT_CONSTEXPR20
+    #define EFP_FMT_CONSTEXPR20
 #endif
 
 // Check if constexpr std::char_traits<>::{compare,length} are supported.
 #if defined(__GLIBCXX__)
-    #if FMT_CPLUSPLUS >= 201703L && defined(_GLIBCXX_RELEASE) \
+    #if EFP_FMT_CPLUSPLUS >= 201703L && defined(_GLIBCXX_RELEASE) \
         && _GLIBCXX_RELEASE >= 7  // GCC 7+ libstdc++ has _GLIBCXX_RELEASE.
-        #define FMT_CONSTEXPR_CHAR_TRAITS constexpr
+        #define EFP_FMT_CONSTEXPR_CHAR_TRAITS constexpr
     #endif
-#elif defined(_LIBCPP_VERSION) && FMT_CPLUSPLUS >= 201703L && _LIBCPP_VERSION >= 4000
-    #define FMT_CONSTEXPR_CHAR_TRAITS constexpr
-#elif FMT_MSC_VERSION >= 1914 && FMT_CPLUSPLUS >= 201703L
-    #define FMT_CONSTEXPR_CHAR_TRAITS constexpr
+#elif defined(_LIBCPP_VERSION) && EFP_FMT_CPLUSPLUS >= 201703L && _LIBCPP_VERSION >= 4000
+    #define EFP_FMT_CONSTEXPR_CHAR_TRAITS constexpr
+#elif EFP_FMT_MSC_VERSION >= 1914 && EFP_FMT_CPLUSPLUS >= 201703L
+    #define EFP_FMT_CONSTEXPR_CHAR_TRAITS constexpr
 #endif
-#ifndef FMT_CONSTEXPR_CHAR_TRAITS
-    #define FMT_CONSTEXPR_CHAR_TRAITS
+#ifndef EFP_FMT_CONSTEXPR_CHAR_TRAITS
+    #define EFP_FMT_CONSTEXPR_CHAR_TRAITS
 #endif
 
 // Check if exceptions are disabled.
-#ifndef FMT_EXCEPTIONS
-    #if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || (FMT_MSC_VERSION && !_HAS_EXCEPTIONS)
-        #define FMT_EXCEPTIONS 0
+#ifndef EFP_FMT_EXCEPTIONS
+    #if (defined(__GNUC__) && !defined(__EXCEPTIONS)) || (EFP_FMT_MSC_VERSION && !_HAS_EXCEPTIONS)
+        #define EFP_FMT_EXCEPTIONS 0
     #else
-        #define FMT_EXCEPTIONS 1
+        #define EFP_FMT_EXCEPTIONS 1
     #endif
 #endif
 
 // Disable [[noreturn]] on MSVC/NVCC because of bogus unreachable code warnings.
-#if FMT_EXCEPTIONS && FMT_HAS_CPP_ATTRIBUTE(noreturn) && !FMT_MSC_VERSION && !defined(__NVCC__)
-    #define FMT_NORETURN [[noreturn]]
+#if EFP_FMT_EXCEPTIONS && EFP_FMT_HAS_CPP_ATTRIBUTE(noreturn) && !EFP_FMT_MSC_VERSION && !defined(__NVCC__)
+    #define EFP_FMT_NORETURN [[noreturn]]
 #else
-    #define FMT_NORETURN
+    #define EFP_FMT_NORETURN
 #endif
 
-#ifndef FMT_NODISCARD
-    #if FMT_HAS_CPP17_ATTRIBUTE(nodiscard)
-        #define FMT_NODISCARD [[nodiscard]]
+#ifndef EFP_FMT_NODISCARD
+    #if EFP_FMT_HAS_CPP17_ATTRIBUTE(nodiscard)
+        #define EFP_FMT_NODISCARD [[nodiscard]]
     #else
-        #define FMT_NODISCARD
+        #define EFP_FMT_NODISCARD
     #endif
 #endif
 
-#ifndef FMT_INLINE
-    #if FMT_GCC_VERSION || FMT_CLANG_VERSION
-        #define FMT_INLINE inline __attribute__((always_inline))
+#ifndef EFP_FMT_INLINE
+    #if EFP_FMT_GCC_VERSION || EFP_FMT_CLANG_VERSION
+        #define EFP_FMT_INLINE inline __attribute__((always_inline))
     #else
-        #define FMT_INLINE inline
+        #define EFP_FMT_INLINE inline
     #endif
 #endif
 
 #ifdef _MSC_VER
-    #define FMT_UNCHECKED_ITERATOR(It) using _Unchecked_type = It  // Mark iterator as checked.
+    #define EFP_FMT_UNCHECKED_ITERATOR(It) using _Unchecked_type = It  // Mark iterator as checked.
 #else
-    #define FMT_UNCHECKED_ITERATOR(It) using unchecked_type = It
+    #define EFP_FMT_UNCHECKED_ITERATOR(It) using unchecked_type = It
 #endif
 
-#ifndef FMT_BEGIN_NAMESPACE
-    #define FMT_BEGIN_NAMESPACE \
+#ifndef EFP_FMT_BEGIN_NAMESPACE
+    #define EFP_FMT_BEGIN_NAMESPACE \
         namespace efp_fmt { \
         inline namespace v10 {
-    #define FMT_END_NAMESPACE \
+    #define EFP_FMT_END_NAMESPACE \
         } \
         }
 #endif
 
-#ifndef FMT_EXPORT
-    #define FMT_EXPORT
-    #define FMT_BEGIN_EXPORT
-    #define FMT_END_EXPORT
+#ifndef EFP_FMT_EXPORT
+    #define EFP_FMT_EXPORT
+    #define EFP_FMT_BEGIN_EXPORT
+    #define EFP_FMT_END_EXPORT
 #endif
 
-#if FMT_GCC_VERSION || FMT_CLANG_VERSION
-    #define FMT_VISIBILITY(value) __attribute__((visibility(value)))
+#if EFP_FMT_GCC_VERSION || EFP_FMT_CLANG_VERSION
+    #define EFP_FMT_VISIBILITY(value) __attribute__((visibility(value)))
 #else
-    #define FMT_VISIBILITY(value)
+    #define EFP_FMT_VISIBILITY(value)
 #endif
 
-#if !defined(FMT_HEADER_ONLY) && defined(_WIN32)
-    #if defined(FMT_LIB_EXPORT)
-        #define FMT_API __declspec(dllexport)
-    #elif defined(FMT_SHARED)
-        #define FMT_API __declspec(dllimport)
+#if !defined(EFP_FMT_HEADER_ONLY) && defined(_WIN32)
+    #if defined(EFP_FMT_LIB_EXPORT)
+        #define EFP_FMT_API __declspec(dllexport)
+    #elif defined(EFP_FMT_SHARED)
+        #define EFP_FMT_API __declspec(dllimport)
     #endif
-#elif defined(FMT_LIB_EXPORT) || defined(FMT_SHARED)
-    #define FMT_API FMT_VISIBILITY("default")
+#elif defined(EFP_FMT_LIB_EXPORT) || defined(EFP_FMT_SHARED)
+    #define EFP_FMT_API EFP_FMT_VISIBILITY("default")
 #endif
-#ifndef FMT_API
-    #define FMT_API
+#ifndef EFP_FMT_API
+    #define EFP_FMT_API
 #endif
 
 // libc++ supports string_view in pre-c++17.
-#if FMT_HAS_INCLUDE(<string_view>) && (FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
+#if EFP_FMT_HAS_INCLUDE(<string_view>) && (EFP_FMT_CPLUSPLUS >= 201703L || defined(_LIBCPP_VERSION))
     #include <string_view>
-    #define FMT_USE_STRING_VIEW
-#elif FMT_HAS_INCLUDE("experimental/string_view") && FMT_CPLUSPLUS >= 201402L
+    #define EFP_FMT_USE_STRING_VIEW
+#elif EFP_FMT_HAS_INCLUDE("experimental/string_view") && EFP_FMT_CPLUSPLUS >= 201402L
     #include <experimental/string_view>
-    #define FMT_USE_EXPERIMENTAL_STRING_VIEW
+    #define EFP_FMT_USE_EXPERIMENTAL_STRING_VIEW
 #endif
 
-#ifndef FMT_UNICODE
-    #define FMT_UNICODE !FMT_MSC_VERSION
+#ifndef EFP_FMT_UNICODE
+    #define EFP_FMT_UNICODE !EFP_FMT_MSC_VERSION
 #endif
 
-#ifndef FMT_CONSTEVAL
-    #if ((FMT_GCC_VERSION >= 1000 || FMT_CLANG_VERSION >= 1101) && (!defined(__apple_build_version__) || __apple_build_version__ >= 14000029L) && FMT_CPLUSPLUS >= 202002L) \
-        || (defined(__cpp_consteval) && (!FMT_MSC_VERSION || _MSC_FULL_VER >= 193030704))
+#ifndef EFP_FMT_CONSTEVAL
+    #if ((EFP_FMT_GCC_VERSION >= 1000 || EFP_FMT_CLANG_VERSION >= 1101) && (!defined(__apple_build_version__) || __apple_build_version__ >= 14000029L) && EFP_FMT_CPLUSPLUS >= 202002L) \
+        || (defined(__cpp_consteval) && (!EFP_FMT_MSC_VERSION || _MSC_FULL_VER >= 193030704))
         // consteval is broken in MSVC before VS2022 and Apple clang before 14.
-        #define FMT_CONSTEVAL consteval
-        #define FMT_HAS_CONSTEVAL
+        #define EFP_FMT_CONSTEVAL consteval
+        #define EFP_FMT_HAS_CONSTEVAL
     #else
-        #define FMT_CONSTEVAL
+        #define EFP_FMT_CONSTEVAL
     #endif
 #endif
 
-#ifndef FMT_USE_NONTYPE_TEMPLATE_ARGS
+#ifndef EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
     #if defined(__cpp_nontype_template_args) \
-        && ((FMT_GCC_VERSION >= 903 && FMT_CPLUSPLUS >= 201709L) \
+        && ((EFP_FMT_GCC_VERSION >= 903 && EFP_FMT_CPLUSPLUS >= 201709L) \
             || __cpp_nontype_template_args >= 201911L) \
         && !defined(__NVCOMPILER) && !defined(__LCC__)
-        #define FMT_USE_NONTYPE_TEMPLATE_ARGS 1
+        #define EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS 1
     #else
-        #define FMT_USE_NONTYPE_TEMPLATE_ARGS 0
+        #define EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS 0
     #endif
 #endif
 
 // Enable minimal optimizations for more compact code in debug mode.
-FMT_GCC_PRAGMA("GCC push_options")
+EFP_FMT_GCC_PRAGMA("GCC push_options")
 #if !defined(__OPTIMIZE__) && !defined(__NVCOMPILER) && !defined(__LCC__) && !defined(__CUDACC__)
-FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
+EFP_FMT_GCC_PRAGMA("GCC optimize(\"Og\")")
 #endif
 
-FMT_BEGIN_NAMESPACE
+EFP_FMT_BEGIN_NAMESPACE
 
 // Implementations of efp::EnableIf and other metafunctions for older systems.
 // template<bool B, typename T = void>
@@ -284,16 +284,16 @@ struct monostate {
 // An enable_if helper to be used in template parameters which results in much
 // shorter symbols: https://godbolt.org/z/sWw4vP. Extra parentheses are needed
 // to workaround a bug in MSVC 2019 (see #1140 and #1186).
-#ifdef FMT_DOC
-    #define FMT_ENABLE_IF(...)
+#ifdef EFP_FMT_DOC
+    #define EFP_FMT_ENABLE_IF(...)
 #else
-    #define FMT_ENABLE_IF(...) efp::EnableIf<(__VA_ARGS__), int> = 0
+    #define EFP_FMT_ENABLE_IF(...) efp::EnableIf<(__VA_ARGS__), int> = 0
 #endif
 
 // This is defined in core.h instead of format.h to avoid injecting in std.
 // It is a template to avoid undesirable implicit conversions to std::byte.
 #ifdef __cpp_lib_byte
-template<typename T, FMT_ENABLE_IF(efp::IsSame<T, std::byte>::value)>
+template<typename T, EFP_FMT_ENABLE_IF(efp::IsSame<T, std::byte>::value)>
 inline auto format_as(T b) -> unsigned char {
     return static_cast<unsigned char>(b);
 }
@@ -304,14 +304,14 @@ namespace detail {
 // https://herbsutter.com/2009/10/18/mailbag-shutting-up-compiler-warnings/.
 // (void)var does not work on many Intel compilers.
 template<typename... T>
-FMT_CONSTEXPR void ignore_unused(const T&...) {}
+EFP_FMT_CONSTEXPR void ignore_unused(const T&...) {}
 
-constexpr FMT_INLINE auto is_constant_evaluated(bool default_value = false) noexcept -> bool {
+constexpr EFP_FMT_INLINE auto is_constant_evaluated(bool default_value = false) noexcept -> bool {
 // Workaround for incompatibility between libstdc++ consteval-based
 // std::is_constant_evaluated() implementation and clang-14.
 // https://github.com/fmtlib/fmt/issues/3247
-#if FMT_CPLUSPLUS >= 202002L && defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 12 \
-    && (FMT_CLANG_VERSION >= 1400 && FMT_CLANG_VERSION < 1500)
+#if EFP_FMT_CPLUSPLUS >= 202002L && defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 12 \
+    && (EFP_FMT_CLANG_VERSION >= 1400 && EFP_FMT_CLANG_VERSION < 1500)
     ignore_unused(default_value);
     return __builtin_is_constant_evaluated();
 #elif defined(__cpp_lib_is_constant_evaluated)
@@ -324,28 +324,28 @@ constexpr FMT_INLINE auto is_constant_evaluated(bool default_value = false) noex
 
 // Suppresses "conditional expression is constant" warnings.
 template<typename T>
-constexpr FMT_INLINE auto const_check(T value) -> T {
+constexpr EFP_FMT_INLINE auto const_check(T value) -> T {
     return value;
 }
 
-FMT_NORETURN FMT_API void assert_fail(const char* file, int line, const char* message);
+EFP_FMT_NORETURN EFP_FMT_API void assert_fail(const char* file, int line, const char* message);
 
-#ifndef FMT_ASSERT
+#ifndef EFP_FMT_ASSERT
     #ifdef NDEBUG
-        // FMT_ASSERT is not empty to avoid -Wempty-body.
-        #define FMT_ASSERT(condition, message) efp_fmt::detail::ignore_unused((condition), (message))
+        // EFP_FMT_ASSERT is not empty to avoid -Wempty-body.
+        #define EFP_FMT_ASSERT(condition, message) efp_fmt::detail::ignore_unused((condition), (message))
     #else
-        #define FMT_ASSERT(condition, message) \
+        #define EFP_FMT_ASSERT(condition, message) \
             ((condition) /* void() fails with -Winvalid-constexpr on clang 4.0.1 */ \
                  ? (void)0 \
                  : efp_fmt::detail::assert_fail(__FILE__, __LINE__, (message)))
     #endif
 #endif
 
-#if defined(FMT_USE_STRING_VIEW)
+#if defined(EFP_FMT_USE_STRING_VIEW)
 template<typename Char>
 using std_string_view = efp::BasicStringView<Char>;
-#elif defined(FMT_USE_EXPERIMENTAL_STRING_VIEW)
+#elif defined(EFP_FMT_USE_EXPERIMENTAL_STRING_VIEW)
 template<typename Char>
 using std_string_view = std::experimental::basic_string_view<Char>;
 #else
@@ -353,10 +353,10 @@ template<typename T>
 struct std_string_view {};
 #endif
 
-#ifdef FMT_USE_INT128
+#ifdef EFP_FMT_USE_INT128
 // Do nothing.
-#elif defined(__SIZEOF_INT128__) && !defined(__NVCC__) && !(FMT_CLANG_VERSION && FMT_MSC_VERSION)
-    #define FMT_USE_INT128 1
+#elif defined(__SIZEOF_INT128__) && !defined(__NVCC__) && !(EFP_FMT_CLANG_VERSION && EFP_FMT_MSC_VERSION)
+    #define EFP_FMT_USE_INT128 1
 using int128_opt = __int128_t;  // An optional native 128-bit integer.
 using uint128_opt = __uint128_t;
 
@@ -365,9 +365,9 @@ inline auto convert_for_visit(T value) -> T {
     return value;
 }
 #else
-    #define FMT_USE_INT128 0
+    #define EFP_FMT_USE_INT128 0
 #endif
-#if !FMT_USE_INT128
+#if !EFP_FMT_USE_INT128
 enum class int128_opt {};
 enum class uint128_opt {};
 
@@ -380,17 +380,17 @@ auto convert_for_visit(T) -> monostate {
 
 // Casts a nonnegative integer to unsigned.
 template<typename Int>
-FMT_CONSTEXPR auto to_unsigned(Int value) -> typename std::make_unsigned<Int>::type {
-    FMT_ASSERT(std::is_unsigned<Int>::value || value >= 0, "negative value");
+EFP_FMT_CONSTEXPR auto to_unsigned(Int value) -> typename std::make_unsigned<Int>::type {
+    EFP_FMT_ASSERT(std::is_unsigned<Int>::value || value >= 0, "negative value");
     return static_cast<typename std::make_unsigned<Int>::type>(value);
 }
 
-FMT_CONSTEXPR inline auto is_utf8() -> bool {
-    FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char section[] = "\u00A7";
+EFP_FMT_CONSTEXPR inline auto is_utf8() -> bool {
+    EFP_FMT_MSC_WARNING(suppress : 4566) constexpr unsigned char section[] = "\u00A7";
 
     // Avoid buggy sign extensions in MSVC's constant evaluation mode (#2297).
     using uchar = unsigned char;
-    return FMT_UNICODE
+    return EFP_FMT_UNICODE
         || (sizeof(section) == 3 && uchar(section[0]) == 0xC2 && uchar(section[1]) == 0xA7);
 }
 }  // namespace detail
@@ -402,7 +402,7 @@ FMT_CONSTEXPR inline auto is_utf8() -> bool {
   compiled with a different ``-std`` option than the client code (which is not
   recommended).
  */
-FMT_EXPORT
+EFP_FMT_EXPORT
 
 template<typename Char>
 class basic_string_view {
@@ -425,9 +425,9 @@ public:
     the size with ``std::char_traits<Char>::length``.
     \endrst
    */
-    FMT_CONSTEXPR_CHAR_TRAITS
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS
 
-    FMT_INLINE
+    EFP_FMT_INLINE
     basic_string_view(const Char* s)
         : data_(s), size_(
                         detail::const_check(
@@ -439,12 +439,12 @@ public:
 
     /** Constructs a string reference from a ``std::basic_string`` object. */
     template<typename Traits, typename Alloc>
-    FMT_CONSTEXPR basic_string_view(const efp::BasicString<Char, Traits, Alloc>& s) noexcept
+    EFP_FMT_CONSTEXPR basic_string_view(const efp::BasicString<Char, Traits, Alloc>& s) noexcept
 
         : data_(s.data()), size_(s.size()) {}
 
-    template<typename S, FMT_ENABLE_IF(efp::IsSame<S, detail::std_string_view<Char>>::value)>
-    FMT_CONSTEXPR basic_string_view(S s) noexcept : data_(s.data()), size_(s.size()) {}
+    template<typename S, EFP_FMT_ENABLE_IF(efp::IsSame<S, detail::std_string_view<Char>>::value)>
+    EFP_FMT_CONSTEXPR basic_string_view(S s) noexcept : data_(s.data()), size_(s.size()) {}
 
     /** Returns a pointer to the string data. */
     constexpr auto data() const noexcept -> const Char* {
@@ -468,25 +468,25 @@ public:
         return data_[pos];
     }
 
-    FMT_CONSTEXPR void remove_prefix(size_t n) noexcept {
+    EFP_FMT_CONSTEXPR void remove_prefix(size_t n) noexcept {
         data_ += n;
         size_ -= n;
     }
 
-    FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(basic_string_view<Char> sv) const noexcept {
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(basic_string_view<Char> sv) const noexcept {
         return size_ >= sv.size_ && std::char_traits<Char>::compare(data_, sv.data_, sv.size_) == 0;
     }
 
-    FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(Char c) const noexcept {
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(Char c) const noexcept {
         return size_ >= 1 && std::char_traits<Char>::eq(*data_, c);
     }
 
-    FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(const Char* s) const {
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS bool starts_with(const Char* s) const {
         return starts_with(basic_string_view<Char>(s));
     }
 
     // Lexicographically compare this string reference to other.
-    FMT_CONSTEXPR_CHAR_TRAITS auto compare(basic_string_view other) const -> int {
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS auto compare(basic_string_view other) const -> int {
         size_t str_size = size_ < other.size_ ? size_ : other.size_;
         int result = std::char_traits<Char>::compare(data_, other.data_, str_size);
         if (result == 0)
@@ -494,7 +494,7 @@ public:
         return result;
     }
 
-    FMT_CONSTEXPR_CHAR_TRAITS friend auto operator==(basic_string_view lhs, basic_string_view rhs)
+    EFP_FMT_CONSTEXPR_CHAR_TRAITS friend auto operator==(basic_string_view lhs, basic_string_view rhs)
         -> bool {
         return lhs.compare(rhs) == 0;
     }
@@ -520,11 +520,11 @@ public:
     }
 };
 
-FMT_EXPORT
+EFP_FMT_EXPORT
 using string_view = basic_string_view<char>;
 
 /** Specifies if ``T`` is a character type. Can be specialized by users. */
-FMT_EXPORT
+EFP_FMT_EXPORT
 
 template<typename T>
 struct is_char: efp::False {};
@@ -540,8 +540,8 @@ struct compile_string {};
 template<typename S>
 struct is_compile_string: std::is_base_of<compile_string, S> {};
 
-template<typename Char, FMT_ENABLE_IF(is_char<Char>::value)>
-FMT_INLINE auto to_string_view(const Char* s) -> basic_string_view<Char> {
+template<typename Char, EFP_FMT_ENABLE_IF(is_char<Char>::value)>
+EFP_FMT_INLINE auto to_string_view(const Char* s) -> basic_string_view<Char> {
     return s;
 }
 
@@ -556,12 +556,12 @@ constexpr auto to_string_view(basic_string_view<Char> s) -> basic_string_view<Ch
     return s;
 }
 
-template<typename Char, FMT_ENABLE_IF(!std::is_empty<std_string_view<Char>>::value)>
+template<typename Char, EFP_FMT_ENABLE_IF(!std::is_empty<std_string_view<Char>>::value)>
 inline auto to_string_view(std_string_view<Char> s) -> basic_string_view<Char> {
     return s;
 }
 
-template<typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
+template<typename S, EFP_FMT_ENABLE_IF(is_compile_string<S>::value)>
 constexpr auto to_string_view(const S& s) -> basic_string_view<typename S::char_type> {
     return basic_string_view<typename S::char_type>(s);
 }
@@ -611,24 +611,24 @@ enum class type {
 template<typename T, typename Char>
 struct type_constant: efp::CtConst<type, type::custom_type> {};
 
-#define FMT_TYPE_CONSTANT(Type, constant) \
+#define EFP_FMT_TYPE_CONSTANT(Type, constant) \
     template<typename Char> \
     struct type_constant<Type, Char>: efp::CtConst<type, type::constant> {}
 
-FMT_TYPE_CONSTANT(int, int_type);
-FMT_TYPE_CONSTANT(unsigned, uint_type);
-FMT_TYPE_CONSTANT(long long, long_long_type);
-FMT_TYPE_CONSTANT(unsigned long long, ulong_long_type);
-FMT_TYPE_CONSTANT(int128_opt, int128_type);
-FMT_TYPE_CONSTANT(uint128_opt, uint128_type);
-FMT_TYPE_CONSTANT(bool, bool_type);
-FMT_TYPE_CONSTANT(Char, char_type);
-FMT_TYPE_CONSTANT(float, float_type);
-FMT_TYPE_CONSTANT(double, double_type);
-FMT_TYPE_CONSTANT(long double, long_double_type);
-FMT_TYPE_CONSTANT(const Char*, cstring_type);
-FMT_TYPE_CONSTANT(basic_string_view<Char>, string_type);
-FMT_TYPE_CONSTANT(const void*, pointer_type);
+EFP_FMT_TYPE_CONSTANT(int, int_type);
+EFP_FMT_TYPE_CONSTANT(unsigned, uint_type);
+EFP_FMT_TYPE_CONSTANT(long long, long_long_type);
+EFP_FMT_TYPE_CONSTANT(unsigned long long, ulong_long_type);
+EFP_FMT_TYPE_CONSTANT(int128_opt, int128_type);
+EFP_FMT_TYPE_CONSTANT(uint128_opt, uint128_type);
+EFP_FMT_TYPE_CONSTANT(bool, bool_type);
+EFP_FMT_TYPE_CONSTANT(Char, char_type);
+EFP_FMT_TYPE_CONSTANT(float, float_type);
+EFP_FMT_TYPE_CONSTANT(double, double_type);
+EFP_FMT_TYPE_CONSTANT(long double, long_double_type);
+EFP_FMT_TYPE_CONSTANT(const Char*, cstring_type);
+EFP_FMT_TYPE_CONSTANT(basic_string_view<Char>, string_type);
+EFP_FMT_TYPE_CONSTANT(const void*, pointer_type);
 
 constexpr bool is_integral_type(type t) {
     return t > type::none_type && t <= type::last_integer_type;
@@ -658,13 +658,13 @@ enum {
     pointer_set = set(type::pointer_type)
 };
 
-FMT_NORETURN FMT_API void throw_format_error(const char* message);
+EFP_FMT_NORETURN EFP_FMT_API void throw_format_error(const char* message);
 
 struct error_handler {
     constexpr error_handler() = default;
 
     // This function is intentionally not constexpr to give a compile-time error.
-    FMT_NORETURN void on_error(const char* message) {
+    EFP_FMT_NORETURN void on_error(const char* message) {
         throw_format_error(message);
     }
 };
@@ -684,7 +684,7 @@ using char_t = typename detail::char_t_impl<S>::type;
   You can use the ``format_parse_context`` type alias for ``char`` instead.
   \endrst
  */
-FMT_EXPORT
+EFP_FMT_EXPORT
 
 template<typename Char>
 class basic_format_parse_context {
@@ -692,7 +692,7 @@ private:
     basic_string_view<Char> format_str_;
     int next_arg_id_;
 
-    FMT_CONSTEXPR void do_check_arg_id(int id);
+    EFP_FMT_CONSTEXPR void do_check_arg_id(int id);
 
 public:
     using char_type = Char;
@@ -720,7 +720,7 @@ public:
     }
 
     /** Advances the begin iterator to ``it``. */
-    FMT_CONSTEXPR void advance_to(iterator it) {
+    EFP_FMT_CONSTEXPR void advance_to(iterator it) {
         format_str_.remove_prefix(detail::to_unsigned(it - begin()));
     }
 
@@ -728,7 +728,7 @@ public:
     Reports an error if using the manual argument indexing; otherwise returns
     the next argument index and switches to the automatic indexing.
    */
-    FMT_CONSTEXPR auto next_arg_id() -> int {
+    EFP_FMT_CONSTEXPR auto next_arg_id() -> int {
         if (next_arg_id_ < 0) {
             detail::throw_format_error("cannot switch from manual to automatic argument indexing");
             return 0;
@@ -742,7 +742,7 @@ public:
     Reports an error if using the automatic argument indexing; otherwise
     switches to the manual indexing.
    */
-    FMT_CONSTEXPR void check_arg_id(int id) {
+    EFP_FMT_CONSTEXPR void check_arg_id(int id) {
         if (next_arg_id_ > 0) {
             detail::throw_format_error("cannot switch from automatic to manual argument indexing");
             return;
@@ -751,12 +751,12 @@ public:
         do_check_arg_id(id);
     }
 
-    FMT_CONSTEXPR void check_arg_id(basic_string_view<Char>) {}
+    EFP_FMT_CONSTEXPR void check_arg_id(basic_string_view<Char>) {}
 
-    FMT_CONSTEXPR void check_dynamic_spec(int arg_id);
+    EFP_FMT_CONSTEXPR void check_dynamic_spec(int arg_id);
 };
 
-FMT_EXPORT
+EFP_FMT_EXPORT
 using format_parse_context = basic_format_parse_context<char>;
 
 namespace detail {
@@ -769,7 +769,7 @@ private:
     using base = basic_format_parse_context<Char>;
 
 public:
-    explicit FMT_CONSTEXPR compile_parse_context(
+    explicit EFP_FMT_CONSTEXPR compile_parse_context(
         basic_string_view<Char> format_str,
         int num_args,
         const type* types,
@@ -785,14 +785,14 @@ public:
         return types_[id];
     }
 
-    FMT_CONSTEXPR auto next_arg_id() -> int {
+    EFP_FMT_CONSTEXPR auto next_arg_id() -> int {
         int id = base::next_arg_id();
         if (id >= num_args_)
             throw_format_error("argument not found");
         return id;
     }
 
-    FMT_CONSTEXPR void check_arg_id(int id) {
+    EFP_FMT_CONSTEXPR void check_arg_id(int id) {
         base::check_arg_id(id);
         if (id >= num_args_)
             throw_format_error("argument not found");
@@ -800,7 +800,7 @@ public:
 
     using base::check_arg_id;
 
-    FMT_CONSTEXPR void check_dynamic_spec(int arg_id) {
+    EFP_FMT_CONSTEXPR void check_dynamic_spec(int arg_id) {
         detail::ignore_unused(arg_id);
 #if !defined(__LCC__)
         if (arg_id < num_args_ && types_ && !is_integral_type(types_[arg_id]))
@@ -824,7 +824,7 @@ inline auto get_container(std::back_insert_iterator<Container> it) -> Container&
 }
 
 template<typename Char, typename InputIt, typename OutputIt>
-FMT_CONSTEXPR auto copy_str(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
+EFP_FMT_CONSTEXPR auto copy_str(InputIt begin, InputIt end, OutputIt out) -> OutputIt {
     while (begin != end)
         *out++ = static_cast<Char>(*begin++);
     return out;
@@ -834,8 +834,8 @@ template<
     typename Char,
     typename T,
     typename U,
-    FMT_ENABLE_IF(efp::IsSame<efp::ConstRemoved<T>, U>::value&& is_char<U>::value)>
-FMT_CONSTEXPR auto copy_str(T* begin, T* end, U* out) -> U* {
+    EFP_FMT_ENABLE_IF(efp::IsSame<efp::ConstRemoved<T>, U>::value&& is_char<U>::value)>
+EFP_FMT_CONSTEXPR auto copy_str(T* begin, T* end, U* out) -> U* {
     if (is_constant_evaluated())
         return copy_str<Char, T*, U*>(begin, end, out);
     auto size = to_unsigned(end - begin);
@@ -859,24 +859,24 @@ private:
 
 protected:
     // Don't initialize ptr_ since it is not accessed to save a few cycles.
-    FMT_MSC_WARNING(suppress : 26495)
+    EFP_FMT_MSC_WARNING(suppress : 26495)
 
     buffer(size_t sz) noexcept : size_(sz), capacity_(sz) {}
 
-    FMT_CONSTEXPR20 buffer(T* p = nullptr, size_t sz = 0, size_t cap = 0) noexcept
+    EFP_FMT_CONSTEXPR20 buffer(T* p = nullptr, size_t sz = 0, size_t cap = 0) noexcept
         : ptr_(p), size_(sz), capacity_(cap) {}
 
-    FMT_CONSTEXPR20 ~buffer() = default;
+    EFP_FMT_CONSTEXPR20 ~buffer() = default;
     buffer(buffer&&) = default;
 
     /** Sets the buffer data and capacity. */
-    FMT_CONSTEXPR void set(T* buf_data, size_t buf_capacity) noexcept {
+    EFP_FMT_CONSTEXPR void set(T* buf_data, size_t buf_capacity) noexcept {
         ptr_ = buf_data;
         capacity_ = buf_capacity;
     }
 
     /** Increases the buffer capacity to hold at least *capacity* elements. */
-    virtual FMT_CONSTEXPR20 void grow(size_t capacity) = 0;
+    virtual EFP_FMT_CONSTEXPR20 void grow(size_t capacity) = 0;
 
 public:
     using value_type = T;
@@ -885,19 +885,19 @@ public:
     buffer(const buffer&) = delete;
     void operator=(const buffer&) = delete;
 
-    FMT_INLINE auto begin() noexcept -> T* {
+    EFP_FMT_INLINE auto begin() noexcept -> T* {
         return ptr_;
     }
 
-    FMT_INLINE auto end() noexcept -> T* {
+    EFP_FMT_INLINE auto end() noexcept -> T* {
         return ptr_ + size_;
     }
 
-    FMT_INLINE auto begin() const noexcept -> const T* {
+    EFP_FMT_INLINE auto begin() const noexcept -> const T* {
         return ptr_;
     }
 
-    FMT_INLINE auto end() const noexcept -> const T* {
+    EFP_FMT_INLINE auto end() const noexcept -> const T* {
         return ptr_ + size_;
     }
 
@@ -912,11 +912,11 @@ public:
     }
 
     /** Returns a pointer to the buffer data (not null-terminated). */
-    FMT_CONSTEXPR auto data() noexcept -> T* {
+    EFP_FMT_CONSTEXPR auto data() noexcept -> T* {
         return ptr_;
     }
 
-    FMT_CONSTEXPR auto data() const noexcept -> const T* {
+    EFP_FMT_CONSTEXPR auto data() const noexcept -> const T* {
         return ptr_;
     }
 
@@ -927,7 +927,7 @@ public:
 
     // Tries resizing the buffer to contain *count* elements. If T is a POD type
     // the new elements may not be initialized.
-    FMT_CONSTEXPR20 void try_resize(size_t count) {
+    EFP_FMT_CONSTEXPR20 void try_resize(size_t count) {
         try_reserve(count);
         size_ = count <= capacity_ ? count : capacity_;
     }
@@ -936,12 +936,12 @@ public:
     // capacity by a smaller amount than requested but guarantees there is space
     // for at least one additional element either by increasing the capacity or by
     // flushing the buffer if it is full.
-    FMT_CONSTEXPR20 void try_reserve(size_t new_capacity) {
+    EFP_FMT_CONSTEXPR20 void try_reserve(size_t new_capacity) {
         if (new_capacity > capacity_)
             grow(new_capacity);
     }
 
-    FMT_CONSTEXPR20 void push_back(const T& value) {
+    EFP_FMT_CONSTEXPR20 void push_back(const T& value) {
         try_reserve(size_ + 1);
         ptr_[size_++] = value;
     }
@@ -951,12 +951,12 @@ public:
     void append(const U* begin, const U* end);
 
     template<typename Idx>
-    FMT_CONSTEXPR auto operator[](Idx index) -> T& {
+    EFP_FMT_CONSTEXPR auto operator[](Idx index) -> T& {
         return ptr_[index];
     }
 
     template<typename Idx>
-    FMT_CONSTEXPR auto operator[](Idx index) const -> const T& {
+    EFP_FMT_CONSTEXPR auto operator[](Idx index) const -> const T& {
         return ptr_[index];
     }
 };
@@ -1003,7 +1003,7 @@ private:
     T data_[buffer_size];
 
 protected:
-    FMT_CONSTEXPR20 void grow(size_t) override {
+    EFP_FMT_CONSTEXPR20 void grow(size_t) override {
         if (this->size() == buffer_size)
             flush();
     }
@@ -1047,7 +1047,7 @@ private:
     T data_[buffer_size];
 
 protected:
-    FMT_CONSTEXPR20 void grow(size_t) override {
+    EFP_FMT_CONSTEXPR20 void grow(size_t) override {
         if (this->size() == this->capacity())
             flush();
     }
@@ -1090,7 +1090,7 @@ public:
 template<typename T>
 class iterator_buffer<T*, T> final: public buffer<T> {
 protected:
-    FMT_CONSTEXPR20 void grow(size_t) override {}
+    EFP_FMT_CONSTEXPR20 void grow(size_t) override {}
 
 public:
     explicit iterator_buffer(T* out, size_t = 0) : buffer<T>(out, 0, ~size_t()) {}
@@ -1110,7 +1110,7 @@ private:
     Container& container_;
 
 protected:
-    FMT_CONSTEXPR20 void grow(size_t capacity) override {
+    EFP_FMT_CONSTEXPR20 void grow(size_t capacity) override {
         container_.resize(capacity);
         this->set(&container_[0], capacity);
     }
@@ -1137,7 +1137,7 @@ private:
     size_t count_ = 0;
 
 protected:
-    FMT_CONSTEXPR20 void grow(size_t) override {
+    EFP_FMT_CONSTEXPR20 void grow(size_t) override {
         if (this->size() != buffer_size)
             return;
         count_ += this->size();
@@ -1154,10 +1154,10 @@ public:
 }  // namespace detail
 
 template<typename Char>
-FMT_CONSTEXPR void basic_format_parse_context<Char>::do_check_arg_id(int id) {
+EFP_FMT_CONSTEXPR void basic_format_parse_context<Char>::do_check_arg_id(int id) {
     // Argument id is only checked at compile-time during parsing because
     // formatting has its own validation.
-    if (detail::is_constant_evaluated() && (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 1200)) {
+    if (detail::is_constant_evaluated() && (!EFP_FMT_GCC_VERSION || EFP_FMT_GCC_VERSION >= 1200)) {
         using context = detail::compile_parse_context<Char>;
         if (id >= static_cast<context*>(this)->num_args())
             detail::throw_format_error("argument not found");
@@ -1165,22 +1165,22 @@ FMT_CONSTEXPR void basic_format_parse_context<Char>::do_check_arg_id(int id) {
 }
 
 template<typename Char>
-FMT_CONSTEXPR void basic_format_parse_context<Char>::check_dynamic_spec(int arg_id) {
-    if (detail::is_constant_evaluated() && (!FMT_GCC_VERSION || FMT_GCC_VERSION >= 1200)) {
+EFP_FMT_CONSTEXPR void basic_format_parse_context<Char>::check_dynamic_spec(int arg_id) {
+    if (detail::is_constant_evaluated() && (!EFP_FMT_GCC_VERSION || EFP_FMT_GCC_VERSION >= 1200)) {
         using context = detail::compile_parse_context<Char>;
         static_cast<context*>(this)->check_dynamic_spec(arg_id);
     }
 }
 
-FMT_EXPORT template<typename Context>
+EFP_FMT_EXPORT template<typename Context>
 class basic_format_arg;
-FMT_EXPORT template<typename Context>
+EFP_FMT_EXPORT template<typename Context>
 class basic_format_args;
-FMT_EXPORT template<typename Context>
+EFP_FMT_EXPORT template<typename Context>
 class dynamic_format_arg_store;
 
 // A formatter for objects of type T.
-FMT_EXPORT
+EFP_FMT_EXPORT
 
 template<typename T, typename Char = char, typename Enable = void>
 struct formatter {
@@ -1203,7 +1203,7 @@ public:
 
     appender(base it) noexcept : base(it) {}
 
-    FMT_UNCHECKED_ITERATOR(appender);
+    EFP_FMT_UNCHECKED_ITERATOR(appender);
 
     auto operator++() noexcept -> appender& {
         return *this;
@@ -1242,13 +1242,13 @@ auto get_buffer(OutputIt out) -> iterator_buffer<OutputIt, T> {
     return iterator_buffer<OutputIt, T>(out);
 }
 
-template<typename T, typename Buf, FMT_ENABLE_IF(std::is_base_of<buffer<char>, Buf>::value)>
+template<typename T, typename Buf, EFP_FMT_ENABLE_IF(std::is_base_of<buffer<char>, Buf>::value)>
 auto get_buffer(std::back_insert_iterator<Buf> out) -> buffer<char>& {
     return get_container(out);
 }
 
 template<typename Buf, typename OutputIt>
-FMT_INLINE auto get_iterator(Buf& buf, OutputIt) -> decltype(buf.out()) {
+EFP_FMT_INLINE auto get_iterator(Buf& buf, OutputIt) -> decltype(buf.out()) {
     return buf.out();
 }
 
@@ -1300,13 +1300,13 @@ struct arg_data<T, Char, NUM_ARGS, 0> {
     T args_[NUM_ARGS != 0 ? NUM_ARGS : +1];
 
     template<typename... U>
-    FMT_CONSTEXPR FMT_INLINE arg_data(const U&... init) : args_ {init...} {}
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE arg_data(const U&... init) : args_ {init...} {}
 
-    FMT_CONSTEXPR FMT_INLINE auto args() const -> const T* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto args() const -> const T* {
         return args_;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto named_args() -> std::nullptr_t {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto named_args() -> std::nullptr_t {
         return nullptr;
     }
 };
@@ -1323,7 +1323,7 @@ struct is_statically_named_arg: efp::False {};
 template<typename T, typename Char>
 struct is_named_arg<named_arg<Char, T>>: efp::True {};
 
-template<typename Char, typename T, typename... Tail, FMT_ENABLE_IF(!is_named_arg<T>::value)>
+template<typename Char, typename T, typename... Tail, EFP_FMT_ENABLE_IF(!is_named_arg<T>::value)>
 void init_named_args(
     named_arg_info<Char>* named_args,
     int arg_count,
@@ -1334,7 +1334,7 @@ void init_named_args(
     init_named_args(named_args, arg_count + 1, named_arg_count, args...);
 }
 
-template<typename Char, typename T, typename... Tail, FMT_ENABLE_IF(is_named_arg<T>::value)>
+template<typename Char, typename T, typename... Tail, EFP_FMT_ENABLE_IF(is_named_arg<T>::value)>
 void init_named_args(
     named_arg_info<Char>* named_args,
     int arg_count,
@@ -1347,7 +1347,7 @@ void init_named_args(
 }
 
 template<typename... Args>
-FMT_CONSTEXPR FMT_INLINE void init_named_args(std::nullptr_t, int, int, const Args&...) {}
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE void init_named_args(std::nullptr_t, int, int, const Args&...) {}
 
 template<bool B = false>
 constexpr auto count() -> size_t {
@@ -1419,48 +1419,48 @@ public:
         named_arg_value<char_type> named_args;
     };
 
-    constexpr FMT_INLINE value() : no_value() {}
+    constexpr EFP_FMT_INLINE value() : no_value() {}
 
-    constexpr FMT_INLINE value(int val) : int_value(val) {}
+    constexpr EFP_FMT_INLINE value(int val) : int_value(val) {}
 
-    constexpr FMT_INLINE value(unsigned val) : uint_value(val) {}
+    constexpr EFP_FMT_INLINE value(unsigned val) : uint_value(val) {}
 
-    constexpr FMT_INLINE value(long long val) : long_long_value(val) {}
+    constexpr EFP_FMT_INLINE value(long long val) : long_long_value(val) {}
 
-    constexpr FMT_INLINE value(unsigned long long val) : ulong_long_value(val) {}
+    constexpr EFP_FMT_INLINE value(unsigned long long val) : ulong_long_value(val) {}
 
-    FMT_INLINE value(int128_opt val) : int128_value(val) {}
+    EFP_FMT_INLINE value(int128_opt val) : int128_value(val) {}
 
-    FMT_INLINE value(uint128_opt val) : uint128_value(val) {}
+    EFP_FMT_INLINE value(uint128_opt val) : uint128_value(val) {}
 
-    constexpr FMT_INLINE value(float val) : float_value(val) {}
+    constexpr EFP_FMT_INLINE value(float val) : float_value(val) {}
 
-    constexpr FMT_INLINE value(double val) : double_value(val) {}
+    constexpr EFP_FMT_INLINE value(double val) : double_value(val) {}
 
-    FMT_INLINE value(long double val) : long_double_value(val) {}
+    EFP_FMT_INLINE value(long double val) : long_double_value(val) {}
 
-    constexpr FMT_INLINE value(bool val) : bool_value(val) {}
+    constexpr EFP_FMT_INLINE value(bool val) : bool_value(val) {}
 
-    constexpr FMT_INLINE value(char_type val) : char_value(val) {}
+    constexpr EFP_FMT_INLINE value(char_type val) : char_value(val) {}
 
-    FMT_CONSTEXPR FMT_INLINE value(const char_type* val) {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE value(const char_type* val) {
         string.data = val;
         if (is_constant_evaluated())
             string.size = {};
     }
 
-    FMT_CONSTEXPR FMT_INLINE value(basic_string_view<char_type> val) {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE value(basic_string_view<char_type> val) {
         string.data = val.data();
         string.size = val.size();
     }
 
-    FMT_INLINE value(const void* val) : pointer(val) {}
+    EFP_FMT_INLINE value(const void* val) : pointer(val) {}
 
-    FMT_INLINE value(const named_arg_info<char_type>* args, size_t size)
+    EFP_FMT_INLINE value(const named_arg_info<char_type>* args, size_t size)
         : named_args {args, size} {}
 
     template<typename T>
-    FMT_CONSTEXPR20 FMT_INLINE value(T& val) {
+    EFP_FMT_CONSTEXPR20 EFP_FMT_INLINE value(T& val) {
         using value_type = efp::ConstRemoved<T>;
         custom.value = const_cast<value_type*>(std::addressof(val));
         // Get the formatter type through the context to allow different contexts
@@ -1495,7 +1495,7 @@ using ulong_type = efp::Conditional<long_short, unsigned, unsigned long long>;
 
 template<typename T>
 struct format_as_result {
-    template<typename U, FMT_ENABLE_IF(std::is_enum<U>::value || std::is_class<U>::value)>
+    template<typename U, EFP_FMT_ENABLE_IF(std::is_enum<U>::value || std::is_class<U>::value)>
     static auto map(U*) -> decltype(format_as(efp::declval<U>()));
     static auto map(...) -> void;
 
@@ -1515,62 +1515,62 @@ template<typename Context>
 struct arg_mapper {
     using char_type = typename Context::char_type;
 
-    FMT_CONSTEXPR FMT_INLINE auto map(signed char val) -> int {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(signed char val) -> int {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(unsigned char val) -> unsigned {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(unsigned char val) -> unsigned {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(short val) -> int {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(short val) -> int {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(unsigned short val) -> unsigned {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(unsigned short val) -> unsigned {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(int val) -> int {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(int val) -> int {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(unsigned val) -> unsigned {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(unsigned val) -> unsigned {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(long val) -> long_type {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(long val) -> long_type {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(unsigned long val) -> ulong_type {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(unsigned long val) -> ulong_type {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(long long val) -> long long {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(long long val) -> long long {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(unsigned long long val) -> unsigned long long {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(unsigned long long val) -> unsigned long long {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(int128_opt val) -> int128_opt {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(int128_opt val) -> int128_opt {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(uint128_opt val) -> uint128_opt {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(uint128_opt val) -> uint128_opt {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(bool val) -> bool {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(bool val) -> bool {
         return val;
     }
 
     template<
         typename T,
-        FMT_ENABLE_IF(efp::IsSame<T, char>::value || efp::IsSame<T, char_type>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto map(T val) -> char_type {
+        EFP_FMT_ENABLE_IF(efp::IsSame<T, char>::value || efp::IsSame<T, char_type>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(T val) -> char_type {
         return val;
     }
 
@@ -1584,59 +1584,59 @@ struct arg_mapper {
              efp::IsSame<T, char16_t>::value || efp::IsSame<T, char32_t>::value)
                 && !efp::IsSame<T, char_type>::value,
             int> = 0>
-    FMT_CONSTEXPR FMT_INLINE auto map(T) -> unformattable_char {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(T) -> unformattable_char {
         return {};
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(float val) -> float {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(float val) -> float {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(double val) -> double {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(double val) -> double {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(long double val) -> long double {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(long double val) -> long double {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(char_type* val) -> const char_type* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(char_type* val) -> const char_type* {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(const char_type* val) -> const char_type* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const char_type* val) -> const char_type* {
         return val;
     }
 
     template<
         typename T,
-        FMT_ENABLE_IF(
+        EFP_FMT_ENABLE_IF(
             is_string<T>::value && !std::is_pointer<T>::value
             && efp::IsSame<char_type, char_t<T>>::value
         )>
-    FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> basic_string_view<char_type> {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const T& val) -> basic_string_view<char_type> {
         return to_string_view(val);
     }
 
     template<
         typename T,
-        FMT_ENABLE_IF(
+        EFP_FMT_ENABLE_IF(
             is_string<T>::value && !std::is_pointer<T>::value
             && !efp::IsSame<char_type, char_t<T>>::value
         )>
-    FMT_CONSTEXPR FMT_INLINE auto map(const T&) -> unformattable_char {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const T&) -> unformattable_char {
         return {};
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(void* val) -> const void* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(void* val) -> const void* {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(const void* val) -> const void* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const void* val) -> const void* {
         return val;
     }
 
-    FMT_CONSTEXPR FMT_INLINE auto map(std::nullptr_t val) -> const void* {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(std::nullptr_t val) -> const void* {
         return val;
     }
 
@@ -1644,23 +1644,23 @@ struct arg_mapper {
     // array overload.
     template<
         typename T,
-        FMT_ENABLE_IF(
+        EFP_FMT_ENABLE_IF(
             std::is_pointer<T>::value || std::is_member_pointer<T>::value
             || std::is_function<typename std::remove_pointer<T>::type>::value
             || (std::is_array<T>::value && !std::is_convertible<T, const char_type*>::value)
         )>
-    FMT_CONSTEXPR auto map(const T&) -> unformattable_pointer {
+    EFP_FMT_CONSTEXPR auto map(const T&) -> unformattable_pointer {
         return {};
     }
 
-    template<typename T, std::size_t N, FMT_ENABLE_IF(!efp::IsSame<T, wchar_t>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto map(const T (&values)[N]) -> const T (&)[N] {
+    template<typename T, std::size_t N, EFP_FMT_ENABLE_IF(!efp::IsSame<T, wchar_t>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const T (&values)[N]) -> const T (&)[N] {
         return values;
     }
 
     // Only map owning types because mapping views can be unsafe.
-    template<typename T, typename U = format_as_t<T>, FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto map(const T& val) -> decltype(this->map(U())) {
+    template<typename T, typename U = format_as_t<T>, EFP_FMT_ENABLE_IF(std::is_arithmetic<U>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const T& val) -> decltype(this->map(U())) {
         return map(format_as(val));
     }
 
@@ -1670,30 +1670,30 @@ struct arg_mapper {
             has_const_formatter<U, Context>()
             || (has_formatter<U, Context>::value && !std::is_const<T>::value)> {};
 
-    template<typename T, FMT_ENABLE_IF(formattable<T>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto do_map(T& val) -> T& {
+    template<typename T, EFP_FMT_ENABLE_IF(formattable<T>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto do_map(T& val) -> T& {
         return val;
     }
 
-    template<typename T, FMT_ENABLE_IF(!formattable<T>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto do_map(T&) -> unformattable {
+    template<typename T, EFP_FMT_ENABLE_IF(!formattable<T>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto do_map(T&) -> unformattable {
         return {};
     }
 
     template<
         typename T,
         typename U = efp::ConstRemoved<T>,
-        FMT_ENABLE_IF(
+        EFP_FMT_ENABLE_IF(
             (std::is_class<U>::value || std::is_enum<U>::value || std::is_union<U>::value)
             && !is_string<U>::value && !is_char<U>::value && !is_named_arg<U>::value
             && !std::is_arithmetic<format_as_t<U>>::value
         )>
-    FMT_CONSTEXPR FMT_INLINE auto map(T& val) -> decltype(this->do_map(val)) {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(T& val) -> decltype(this->do_map(val)) {
         return do_map(val);
     }
 
-    template<typename T, FMT_ENABLE_IF(is_named_arg<T>::value)>
-    FMT_CONSTEXPR FMT_INLINE auto map(const T& named_arg) -> decltype(this->map(named_arg.value)) {
+    template<typename T, EFP_FMT_ENABLE_IF(is_named_arg<T>::value)>
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto map(const T& named_arg) -> decltype(this->map(named_arg.value)) {
         return map(named_arg.value);
     }
 
@@ -1735,11 +1735,11 @@ auto copy_str(InputIt begin, InputIt end, std::back_insert_iterator<efp::String>
 }
 
 template<typename Char, typename R, typename OutputIt>
-FMT_CONSTEXPR auto copy_str(R&& rng, OutputIt out) -> OutputIt {
+EFP_FMT_CONSTEXPR auto copy_str(R&& rng, OutputIt out) -> OutputIt {
     return detail::copy_str<Char>(rng.begin(), rng.end(), out);
 }
 
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 500
+#if EFP_FMT_GCC_VERSION && EFP_FMT_GCC_VERSION < 500
 // A workaround for gcc 4.8 to make void_t work in a SFINAE context.
 template<typename...>
 struct void_t_impl {
@@ -1776,7 +1776,7 @@ private:
     const void* locale_;  // A type-erased pointer to std::locale.
 
 public:
-    constexpr FMT_INLINE locale_ref() : locale_(nullptr) {}
+    constexpr EFP_FMT_INLINE locale_ref() : locale_(nullptr) {}
 
     template<typename Locale>
     explicit locale_ref(const Locale& loc);
@@ -1806,8 +1806,8 @@ template<typename T, typename Char>
 struct type_is_unformattable_for;
 #endif
 
-template<bool PACKED, typename Context, typename T, FMT_ENABLE_IF(PACKED)>
-FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
+template<bool PACKED, typename Context, typename T, EFP_FMT_ENABLE_IF(PACKED)>
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto make_arg(T& val) -> value<Context> {
     using arg_type = efp::CVRefRemoved<decltype(arg_mapper<Context>().map(val))>;
 
     constexpr bool formattable_char = !efp::IsSame<arg_type, unformattable_char>::value;
@@ -1834,20 +1834,20 @@ FMT_CONSTEXPR FMT_INLINE auto make_arg(T& val) -> value<Context> {
 }
 
 template<typename Context, typename T>
-FMT_CONSTEXPR auto make_arg(T& val) -> basic_format_arg<Context> {
+EFP_FMT_CONSTEXPR auto make_arg(T& val) -> basic_format_arg<Context> {
     auto arg = basic_format_arg<Context>();
     arg.type_ = mapped_type_constant<T, Context>::value;
     arg.value_ = make_arg<true, Context>(val);
     return arg;
 }
 
-template<bool PACKED, typename Context, typename T, FMT_ENABLE_IF(!PACKED)>
-FMT_CONSTEXPR inline auto make_arg(T& val) -> basic_format_arg<Context> {
+template<bool PACKED, typename Context, typename T, EFP_FMT_ENABLE_IF(!PACKED)>
+EFP_FMT_CONSTEXPR inline auto make_arg(T& val) -> basic_format_arg<Context> {
     return make_arg<Context>(val);
 }
 }  // namespace detail
 
-FMT_BEGIN_EXPORT
+EFP_FMT_BEGIN_EXPORT
 
 // A formatting argument. It is a trivially copyable/constructible type to
 // allow storage in basic_memory_buffer.
@@ -1858,10 +1858,10 @@ private:
     detail::type type_;
 
     template<typename ContextType, typename T>
-    friend FMT_CONSTEXPR auto detail::make_arg(T& value) -> basic_format_arg<ContextType>;
+    friend EFP_FMT_CONSTEXPR auto detail::make_arg(T& value) -> basic_format_arg<ContextType>;
 
     template<typename Visitor, typename Ctx>
-    friend FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis, const basic_format_arg<Ctx>& arg)
+    friend EFP_FMT_CONSTEXPR auto visit_format_arg(Visitor&& vis, const basic_format_arg<Ctx>& arg)
         -> decltype(vis(0));
 
     friend class basic_format_args<Context>;
@@ -1916,7 +1916,7 @@ public:
  */
 // DEPRECATED!
 template<typename Visitor, typename Context>
-FMT_CONSTEXPR FMT_INLINE auto visit_format_arg(Visitor&& vis, const basic_format_arg<Context>& arg)
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto visit_format_arg(Visitor&& vis, const basic_format_arg<Context>& arg)
     -> decltype(vis(0)) {
     switch (arg.type_) {
         case detail::type::none_type:
@@ -1990,11 +1990,11 @@ public:
         return args_.get(id);
     }
 
-    FMT_CONSTEXPR auto arg(basic_string_view<Char> name) -> format_arg {
+    EFP_FMT_CONSTEXPR auto arg(basic_string_view<Char> name) -> format_arg {
         return args_.get(name);
     }
 
-    FMT_CONSTEXPR auto arg_id(basic_string_view<Char> name) -> int {
+    EFP_FMT_CONSTEXPR auto arg_id(basic_string_view<Char> name) -> int {
         return args_.get_id(name);
     }
 
@@ -2002,7 +2002,7 @@ public:
         return args_;
     }
 
-    FMT_CONSTEXPR auto error_handler() -> detail::error_handler {
+    EFP_FMT_CONSTEXPR auto error_handler() -> detail::error_handler {
         return {};
     }
 
@@ -2011,7 +2011,7 @@ public:
     }
 
     // Returns an iterator to the beginning of the output range.
-    FMT_CONSTEXPR auto out() -> iterator {
+    EFP_FMT_CONSTEXPR auto out() -> iterator {
         return out_;
     }
 
@@ -2021,7 +2021,7 @@ public:
             out_ = it;
     }
 
-    FMT_CONSTEXPR auto locale() -> detail::locale_ref {
+    EFP_FMT_CONSTEXPR auto locale() -> detail::locale_ref {
         return loc_;
     }
 };
@@ -2044,7 +2044,7 @@ using is_formattable = efp::Bool<!std::is_base_of<
  */
 template<typename Context, typename... Args>
 class format_arg_store
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
+#if EFP_FMT_GCC_VERSION && EFP_FMT_GCC_VERSION < 409
     // Workaround a GCC template argument substitution bug.
     :
     public basic_format_args<Context>
@@ -2068,9 +2068,9 @@ private:
 
 public:
     template<typename... T>
-    FMT_CONSTEXPR FMT_INLINE format_arg_store(T&... args)
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE format_arg_store(T&... args)
         :
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
+#if EFP_FMT_GCC_VERSION && EFP_FMT_GCC_VERSION < 409
           basic_format_args<Context>(*this),
 #endif
           data_ {detail::make_arg<is_packed, Context>(args)...} {
@@ -2110,7 +2110,7 @@ inline auto arg(const Char* name, const T& arg) -> detail::named_arg<Char, T> {
     return {name, arg};
 }
 
-FMT_END_EXPORT
+EFP_FMT_END_EXPORT
 
 /**
   \rst
@@ -2153,13 +2153,13 @@ private:
         return (desc_ & detail::has_named_args_bit) != 0;
     }
 
-    FMT_CONSTEXPR auto type(int index) const -> detail::type {
+    EFP_FMT_CONSTEXPR auto type(int index) const -> detail::type {
         int shift = index * detail::packed_arg_bits;
         unsigned int mask = (1 << detail::packed_arg_bits) - 1;
         return static_cast<detail::type>((desc_ >> shift) & mask);
     }
 
-    constexpr FMT_INLINE
+    constexpr EFP_FMT_INLINE
     basic_format_args(unsigned long long desc, const detail::value<Context>* values)
         : desc_(desc), values_(values) {}
 
@@ -2175,7 +2175,7 @@ public:
    \endrst
    */
     template<typename... Args>
-    constexpr FMT_INLINE basic_format_args(const format_arg_store<Context, Args...>& store)
+    constexpr EFP_FMT_INLINE basic_format_args(const format_arg_store<Context, Args...>& store)
         : basic_format_args(format_arg_store<Context, Args...>::desc, store.data_.args()) {}
 
     /**
@@ -2184,7 +2184,7 @@ public:
    `~efp_fmt::dynamic_format_arg_store`.
    \endrst
    */
-    constexpr FMT_INLINE basic_format_args(const dynamic_format_arg_store<Context>& store)
+    constexpr EFP_FMT_INLINE basic_format_args(const dynamic_format_arg_store<Context>& store)
         : basic_format_args(store.get_types(), store.data()) {}
 
     /**
@@ -2196,7 +2196,7 @@ public:
         : basic_format_args(detail::is_unpacked_bit | detail::to_unsigned(count), args) {}
 
     /** Returns the argument with the specified id. */
-    FMT_CONSTEXPR auto get(int id) const -> format_arg {
+    EFP_FMT_CONSTEXPR auto get(int id) const -> format_arg {
         format_arg arg;
         if (!is_packed()) {
             if (id < max_size())
@@ -2239,25 +2239,25 @@ public:
 /** An alias to ``basic_format_args<format_context>``. */
 // A separate type would result in shorter symbols but break ABI compatibility
 // between clang and gcc on ARM (#1919).
-FMT_EXPORT using format_args = basic_format_args<format_context>;
+EFP_FMT_EXPORT using format_args = basic_format_args<format_context>;
 
 // We cannot use enum classes as bit fields because of a gcc bug, so we put them
 // in namespaces instead (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=61414).
 // Additionally, if an underlying type is specified, older gcc incorrectly warns
 // that the type is too small. Both bugs are fixed in gcc 9.3.
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 903
-    #define FMT_ENUM_UNDERLYING_TYPE(type)
+#if EFP_FMT_GCC_VERSION && EFP_FMT_GCC_VERSION < 903
+    #define EFP_FMT_ENUM_UNDERLYING_TYPE(type)
 #else
-    #define FMT_ENUM_UNDERLYING_TYPE(type) : type
+    #define EFP_FMT_ENUM_UNDERLYING_TYPE(type) : type
 #endif
 namespace align {
-enum type FMT_ENUM_UNDERLYING_TYPE(unsigned char) {none, left, right, center, numeric};
+enum type EFP_FMT_ENUM_UNDERLYING_TYPE(unsigned char) {none, left, right, center, numeric};
 }
 
 using align_t = align::type;
 
 namespace sign {
-enum type FMT_ENUM_UNDERLYING_TYPE(unsigned char) {none, minus, plus, space};
+enum type EFP_FMT_ENUM_UNDERLYING_TYPE(unsigned char) {none, minus, plus, space};
 }
 
 using sign_t = sign::type;
@@ -2274,9 +2274,9 @@ private:
     unsigned char size_ = 1;
 
 public:
-    FMT_CONSTEXPR void operator=(basic_string_view<Char> s) {
+    EFP_FMT_CONSTEXPR void operator=(basic_string_view<Char> s) {
         auto size = s.size();
-        FMT_ASSERT(size <= max_size, "invalid fill");
+        EFP_FMT_ASSERT(size <= max_size, "invalid fill");
         for (size_t i = 0; i < size; ++i)
             data_[i] = s[i];
         size_ = static_cast<unsigned char>(size);
@@ -2290,11 +2290,11 @@ public:
         return data_;
     }
 
-    FMT_CONSTEXPR auto operator[](size_t index) -> Char& {
+    EFP_FMT_CONSTEXPR auto operator[](size_t index) -> Char& {
         return data_[index];
     }
 
-    FMT_CONSTEXPR auto operator[](size_t index) const -> const Char& {
+    EFP_FMT_CONSTEXPR auto operator[](size_t index) const -> const Char& {
         return data_[index];
     }
 };
@@ -2346,14 +2346,14 @@ enum class arg_id_kind { none, index, name };
 // An argument reference.
 template<typename Char>
 struct arg_ref {
-    FMT_CONSTEXPR arg_ref() : kind(arg_id_kind::none), val() {}
+    EFP_FMT_CONSTEXPR arg_ref() : kind(arg_id_kind::none), val() {}
 
-    FMT_CONSTEXPR explicit arg_ref(int index) : kind(arg_id_kind::index), val(index) {}
+    EFP_FMT_CONSTEXPR explicit arg_ref(int index) : kind(arg_id_kind::index), val(index) {}
 
-    FMT_CONSTEXPR explicit arg_ref(basic_string_view<Char> name)
+    EFP_FMT_CONSTEXPR explicit arg_ref(basic_string_view<Char> name)
         : kind(arg_id_kind::name), val(name) {}
 
-    FMT_CONSTEXPR auto operator=(int idx) -> arg_ref& {
+    EFP_FMT_CONSTEXPR auto operator=(int idx) -> arg_ref& {
         kind = arg_id_kind::index;
         val.index = idx;
         return *this;
@@ -2362,9 +2362,9 @@ struct arg_ref {
     arg_id_kind kind;
 
     union value {
-        FMT_CONSTEXPR value(int idx = 0) : index(idx) {}
+        EFP_FMT_CONSTEXPR value(int idx = 0) : index(idx) {}
 
-        FMT_CONSTEXPR value(basic_string_view<Char> n) : name(n) {}
+        EFP_FMT_CONSTEXPR value(basic_string_view<Char> n) : name(n) {}
 
         int index;
         basic_string_view<Char> name;
@@ -2381,19 +2381,19 @@ struct dynamic_format_specs: format_specs<Char> {
 };
 
 // Converts a character to ASCII. Returns '\0' on conversion failure.
-template<typename Char, FMT_ENABLE_IF(std::is_integral<Char>::value)>
+template<typename Char, EFP_FMT_ENABLE_IF(std::is_integral<Char>::value)>
 constexpr auto to_ascii(Char c) -> char {
     return c <= 0xff ? static_cast<char>(c) : '\0';
 }
 
-template<typename Char, FMT_ENABLE_IF(std::is_enum<Char>::value)>
+template<typename Char, EFP_FMT_ENABLE_IF(std::is_enum<Char>::value)>
 constexpr auto to_ascii(Char c) -> char {
     return c <= 0xff ? static_cast<char>(c) : '\0';
 }
 
 // Returns the number of code units in a code point or 1 on error.
 template<typename Char>
-FMT_CONSTEXPR auto code_point_length(const Char* begin) -> int {
+EFP_FMT_CONSTEXPR auto code_point_length(const Char* begin) -> int {
     if (const_check(sizeof(Char) != 1))
         return 1;
     auto c = static_cast<unsigned char>(*begin);
@@ -2402,7 +2402,7 @@ FMT_CONSTEXPR auto code_point_length(const Char* begin) -> int {
 
 // Return the result via the out param to workaround gcc bug 77539.
 template<bool IS_CONSTEXPR, typename T, typename Ptr = const T*>
-FMT_CONSTEXPR auto find(Ptr first, Ptr last, T value, Ptr& out) -> bool {
+EFP_FMT_CONSTEXPR auto find(Ptr first, Ptr last, T value, Ptr& out) -> bool {
     for (out = first; out != last; ++out) {
         if (*out == value)
             return true;
@@ -2420,9 +2420,9 @@ inline auto find<false, char>(const char* first, const char* last, char value, c
 // Parses the range [begin, end) as an unsigned integer. This function assumes
 // that the range is non-empty and the first character is a digit.
 template<typename Char>
-FMT_CONSTEXPR auto
+EFP_FMT_CONSTEXPR auto
 parse_nonnegative_int(const Char*& begin, const Char* end, int error_value) noexcept -> int {
-    FMT_ASSERT(begin != end && '0' <= *begin && *begin <= '9', "");
+    EFP_FMT_ASSERT(begin != end && '0' <= *begin && *begin <= '9', "");
     unsigned value = 0, prev = 0;
     auto p = begin;
     do {
@@ -2442,7 +2442,7 @@ parse_nonnegative_int(const Char*& begin, const Char* end, int error_value) noex
         : error_value;
 }
 
-FMT_CONSTEXPR inline auto parse_align(char c) -> align_t {
+EFP_FMT_CONSTEXPR inline auto parse_align(char c) -> align_t {
     switch (c) {
         case '<':
             return align::left;
@@ -2460,7 +2460,7 @@ constexpr auto is_name_start(Char c) -> bool {
 }
 
 template<typename Char, typename Handler>
-FMT_CONSTEXPR auto do_parse_arg_id(const Char* begin, const Char* end, Handler&& handler)
+EFP_FMT_CONSTEXPR auto do_parse_arg_id(const Char* begin, const Char* end, Handler&& handler)
     -> const Char* {
     Char c = *begin;
     if (c >= '0' && c <= '9') {
@@ -2489,9 +2489,9 @@ FMT_CONSTEXPR auto do_parse_arg_id(const Char* begin, const Char* end, Handler&&
 }
 
 template<typename Char, typename Handler>
-FMT_CONSTEXPR FMT_INLINE auto parse_arg_id(const Char* begin, const Char* end, Handler&& handler)
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto parse_arg_id(const Char* begin, const Char* end, Handler&& handler)
     -> const Char* {
-    FMT_ASSERT(begin != end, "");
+    EFP_FMT_ASSERT(begin != end, "");
     Char c = *begin;
     if (c != '}' && c != ':')
         return do_parse_arg_id(begin, end, handler);
@@ -2504,19 +2504,19 @@ struct dynamic_spec_id_handler {
     basic_format_parse_context<Char>& ctx;
     arg_ref<Char>& ref;
 
-    FMT_CONSTEXPR void on_auto() {
+    EFP_FMT_CONSTEXPR void on_auto() {
         int id = ctx.next_arg_id();
         ref = arg_ref<Char>(id);
         ctx.check_dynamic_spec(id);
     }
 
-    FMT_CONSTEXPR void on_index(int id) {
+    EFP_FMT_CONSTEXPR void on_index(int id) {
         ref = arg_ref<Char>(id);
         ctx.check_arg_id(id);
         ctx.check_dynamic_spec(id);
     }
 
-    FMT_CONSTEXPR void on_name(basic_string_view<Char> id) {
+    EFP_FMT_CONSTEXPR void on_name(basic_string_view<Char> id) {
         ref = arg_ref<Char>(id);
         ctx.check_arg_id(id);
     }
@@ -2524,14 +2524,14 @@ struct dynamic_spec_id_handler {
 
 // Parses [integer | "{" [arg_id] "}"].
 template<typename Char>
-FMT_CONSTEXPR auto parse_dynamic_spec(
+EFP_FMT_CONSTEXPR auto parse_dynamic_spec(
     const Char* begin,
     const Char* end,
     int& value,
     arg_ref<Char>& ref,
     basic_format_parse_context<Char>& ctx
 ) -> const Char* {
-    FMT_ASSERT(begin != end, "");
+    EFP_FMT_ASSERT(begin != end, "");
     if ('0' <= *begin && *begin <= '9') {
         int val = parse_nonnegative_int(begin, end, -1);
         if (val != -1)
@@ -2551,7 +2551,7 @@ FMT_CONSTEXPR auto parse_dynamic_spec(
 }
 
 template<typename Char>
-FMT_CONSTEXPR auto parse_precision(
+EFP_FMT_CONSTEXPR auto parse_precision(
     const Char* begin,
     const Char* end,
     int& value,
@@ -2570,7 +2570,7 @@ enum class state { start, align, sign, hash, zero, width, precision, locale };
 
 // Parses standard format specifiers.
 template<typename Char>
-FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto parse_format_specs(
     const Char* begin,
     const Char* end,
     dynamic_format_specs<Char>& specs,
@@ -2590,7 +2590,7 @@ FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
     struct {
         state current_state = state::start;
 
-        FMT_CONSTEXPR void operator()(state s, bool valid = true) {
+        EFP_FMT_CONSTEXPR void operator()(state s, bool valid = true) {
             if (current_state >= s || !valid)
                 throw_format_error("invalid format specifier");
             current_state = s;
@@ -2605,7 +2605,7 @@ FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
         dynamic_format_specs<Char>& specs;
         type arg_type;
 
-        FMT_CONSTEXPR auto operator()(pres pres_type, int set) -> const Char* {
+        EFP_FMT_CONSTEXPR auto operator()(pres pres_type, int set) -> const Char* {
             if (!in(arg_type, set)) {
                 if (arg_type == type::none_type)
                     return begin;
@@ -2756,21 +2756,21 @@ FMT_CONSTEXPR FMT_INLINE auto parse_format_specs(
 }
 
 template<typename Char, typename Handler>
-FMT_CONSTEXPR auto parse_replacement_field(const Char* begin, const Char* end, Handler&& handler)
+EFP_FMT_CONSTEXPR auto parse_replacement_field(const Char* begin, const Char* end, Handler&& handler)
     -> const Char* {
     struct id_adapter {
         Handler& handler;
         int arg_id;
 
-        FMT_CONSTEXPR void on_auto() {
+        EFP_FMT_CONSTEXPR void on_auto() {
             arg_id = handler.on_arg_id();
         }
 
-        FMT_CONSTEXPR void on_index(int id) {
+        EFP_FMT_CONSTEXPR void on_index(int id) {
             arg_id = handler.on_arg_id(id);
         }
 
-        FMT_CONSTEXPR void on_name(basic_string_view<Char> id) {
+        EFP_FMT_CONSTEXPR void on_name(basic_string_view<Char> id) {
             arg_id = handler.on_arg_id(id);
         }
     };
@@ -2800,7 +2800,7 @@ FMT_CONSTEXPR auto parse_replacement_field(const Char* begin, const Char* end, H
 }
 
 template<bool IS_CONSTEXPR, typename Char, typename Handler>
-FMT_CONSTEXPR FMT_INLINE void
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE void
 parse_format_string(basic_string_view<Char> format_str, Handler&& handler) {
     auto begin = format_str.data();
     auto end = begin + format_str.size();
@@ -2824,7 +2824,7 @@ parse_format_string(basic_string_view<Char> format_str, Handler&& handler) {
     }
 
     struct writer {
-        FMT_CONSTEXPR void operator()(const Char* from, const Char* to) {
+        EFP_FMT_CONSTEXPR void operator()(const Char* from, const Char* to) {
             if (from == to)
                 return;
             for (;;) {
@@ -2864,7 +2864,7 @@ struct strip_named_arg<T, true> {
 };
 
 template<typename T, typename ParseContext>
-FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx) -> decltype(ctx.begin()) {
+EFP_FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx) -> decltype(ctx.begin()) {
     using char_type = typename ParseContext::char_type;
     using context = buffer_context<char_type>;
     using mapped_type = efp::Conditional<
@@ -2885,7 +2885,7 @@ FMT_CONSTEXPR auto parse_format_specs(ParseContext& ctx) -> decltype(ctx.begin()
 
 // Checks char specs and returns true iff the presentation type is char-like.
 template<typename Char>
-FMT_CONSTEXPR auto check_char_specs(const format_specs<Char>& specs) -> bool {
+EFP_FMT_CONSTEXPR auto check_char_specs(const format_specs<Char>& specs) -> bool {
     if (specs.type != presentation_type::none && specs.type != presentation_type::chr
         && specs.type != presentation_type::debug) {
         return false;
@@ -2895,7 +2895,7 @@ FMT_CONSTEXPR auto check_char_specs(const format_specs<Char>& specs) -> bool {
     return true;
 }
 
-#if FMT_USE_NONTYPE_TEMPLATE_ARGS
+#if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
 template<int N, typename T, typename... Args, typename Char>
 constexpr auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
     if constexpr (is_statically_named_arg<T>()) {
@@ -2910,8 +2910,8 @@ constexpr auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
 #endif
 
 template<typename... Args, typename Char>
-FMT_CONSTEXPR auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
-#if FMT_USE_NONTYPE_TEMPLATE_ARGS
+EFP_FMT_CONSTEXPR auto get_arg_index_by_name(basic_string_view<Char> name) -> int {
+#if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
     if constexpr (sizeof...(Args) > 0)
         return get_arg_index_by_name<0, Args...>(name);
 #endif
@@ -2936,23 +2936,23 @@ private:
     parse_func parse_funcs_[num_args > 0 ? static_cast<size_t>(num_args) : 1];
 
 public:
-    explicit FMT_CONSTEXPR format_string_checker(basic_string_view<Char> fmt)
+    explicit EFP_FMT_CONSTEXPR format_string_checker(basic_string_view<Char> fmt)
         : types_ {mapped_type_constant<Args, buffer_context<Char>>::value...},
           context_(fmt, num_args, types_),
           parse_funcs_ {&parse_format_specs<Args, parse_context_type>...} {}
 
-    FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
+    EFP_FMT_CONSTEXPR void on_text(const Char*, const Char*) {}
 
-    FMT_CONSTEXPR auto on_arg_id() -> int {
+    EFP_FMT_CONSTEXPR auto on_arg_id() -> int {
         return context_.next_arg_id();
     }
 
-    FMT_CONSTEXPR auto on_arg_id(int id) -> int {
+    EFP_FMT_CONSTEXPR auto on_arg_id(int id) -> int {
         return context_.check_arg_id(id), id;
     }
 
-    FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
-#if FMT_USE_NONTYPE_TEMPLATE_ARGS
+    EFP_FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
+#if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
         auto index = get_arg_index_by_name<Args...>(id);
         if (index < 0)
             on_error("named argument is not found");
@@ -2964,39 +2964,39 @@ public:
 #endif
     }
 
-    FMT_CONSTEXPR void on_replacement_field(int id, const Char* begin) {
+    EFP_FMT_CONSTEXPR void on_replacement_field(int id, const Char* begin) {
         on_format_specs(id, begin, begin);  // Call parse() on empty specs.
     }
 
-    FMT_CONSTEXPR auto on_format_specs(int id, const Char* begin, const Char*) -> const Char* {
+    EFP_FMT_CONSTEXPR auto on_format_specs(int id, const Char* begin, const Char*) -> const Char* {
         context_.advance_to(begin);
         // id >= 0 check is a workaround for gcc 10 bug (#2065).
         return id >= 0 && id < num_args ? parse_funcs_[id](context_) : begin;
     }
 
-    FMT_CONSTEXPR void on_error(const char* message) {
+    EFP_FMT_CONSTEXPR void on_error(const char* message) {
         throw_format_error(message);
     }
 };
 
 // Reports a compile-time error if S is not a valid format string.
-template<typename..., typename S, FMT_ENABLE_IF(!is_compile_string<S>::value)>
-FMT_INLINE void check_format_string(const S&) {
-#ifdef FMT_ENFORCE_COMPILE_STRING
+template<typename..., typename S, EFP_FMT_ENABLE_IF(!is_compile_string<S>::value)>
+EFP_FMT_INLINE void check_format_string(const S&) {
+#ifdef EFP_FMT_ENFORCE_COMPILE_STRING
     static_assert(
         is_compile_string<S>::value,
-        "FMT_ENFORCE_COMPILE_STRING requires all format strings to use "
-        "FMT_STRING."
+        "EFP_FMT_ENFORCE_COMPILE_STRING requires all format strings to use "
+        "EFP_FMT_STRING."
     );
 #endif
 }
 
-template<typename... Args, typename S, FMT_ENABLE_IF(is_compile_string<S>::value)>
+template<typename... Args, typename S, EFP_FMT_ENABLE_IF(is_compile_string<S>::value)>
 void check_format_string(S format_str) {
     using char_t = typename S::char_type;
-    FMT_CONSTEXPR auto s = basic_string_view<char_t>(format_str);
+    EFP_FMT_CONSTEXPR auto s = basic_string_view<char_t>(format_str);
     using checker = format_string_checker<char_t, efp::CVRefRemoved<Args>...>;
-    FMT_CONSTEXPR bool error = (parse_format_string<true>(s, checker(s)), true);
+    EFP_FMT_CONSTEXPR bool error = (parse_format_string<true>(s, checker(s)), true);
     ignore_unused(error);
 }
 
@@ -3020,13 +3020,13 @@ void vformat_to(
     locale_ref loc = {}
 );
 
-FMT_API void vprint_mojibake(std::FILE*, string_view, format_args);
+EFP_FMT_API void vprint_mojibake(std::FILE*, string_view, format_args);
 #ifndef _WIN32
 inline void vprint_mojibake(std::FILE*, string_view, format_args) {}
 #endif
 }  // namespace detail
 
-FMT_BEGIN_EXPORT
+EFP_FMT_BEGIN_EXPORT
 
 // A formatter specialization for natively supported types.
 template<typename T, typename Char>
@@ -3039,7 +3039,7 @@ private:
 
 public:
     template<typename ParseContext>
-    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char* {
+    EFP_FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char* {
         auto type = detail::type_constant<T, Char>::value;
         auto end = detail::parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, type);
         if (type == detail::type::char_type)
@@ -3049,16 +3049,16 @@ public:
 
     template<
         detail::type U = detail::type_constant<T, Char>::value,
-        FMT_ENABLE_IF(
+        EFP_FMT_ENABLE_IF(
             U == detail::type::string_type || U == detail::type::cstring_type
             || U == detail::type::char_type
         )>
-    FMT_CONSTEXPR void set_debug_format(bool set = true) {
+    EFP_FMT_CONSTEXPR void set_debug_format(bool set = true) {
         specs_.type = set ? presentation_type::debug : presentation_type::none;
     }
 
     template<typename FormatContext>
-    FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const -> decltype(ctx.out());
+    EFP_FMT_CONSTEXPR auto format(const T& val, FormatContext& ctx) const -> decltype(ctx.out());
 };
 
 template<typename Char = char>
@@ -3075,8 +3075,8 @@ private:
 public:
     template<
         typename S,
-        FMT_ENABLE_IF(std::is_convertible<const S&, basic_string_view<Char>>::value)>
-    FMT_CONSTEVAL FMT_INLINE basic_format_string(const S& s) : str_(s) {
+        EFP_FMT_ENABLE_IF(std::is_convertible<const S&, basic_string_view<Char>>::value)>
+    EFP_FMT_CONSTEVAL EFP_FMT_INLINE basic_format_string(const S& s) : str_(s) {
         static_assert(
             detail::count<
                 (std::is_base_of<detail::view, efp::ReferenceRemoved<Args>>::value
@@ -3084,7 +3084,7 @@ public:
                 == 0,
             "passing views as lvalues is disallowed"
         );
-#ifdef FMT_HAS_CONSTEVAL
+#ifdef EFP_FMT_HAS_CONSTEVAL
         if constexpr (detail::count_named_args<Args...>() == detail::count_statically_named_args<Args...>()) {
             using checker = detail::format_string_checker<Char, efp::CVRefRemoved<Args>...>;
             detail::parse_format_string<true>(str_, checker(s));
@@ -3096,16 +3096,16 @@ public:
 
     basic_format_string(runtime_format_string<Char> fmt) : str_(fmt.str) {}
 
-    FMT_INLINE operator basic_string_view<Char>() const {
+    EFP_FMT_INLINE operator basic_string_view<Char>() const {
         return str_;
     }
 
-    FMT_INLINE auto get() const -> basic_string_view<Char> {
+    EFP_FMT_INLINE auto get() const -> basic_string_view<Char> {
         return str_;
     }
 };
 
-#if FMT_GCC_VERSION && FMT_GCC_VERSION < 409
+#if EFP_FMT_GCC_VERSION && EFP_FMT_GCC_VERSION < 409
 // Workaround broken conversion on older gcc.
 template<typename...>
 using format_string = string_view;
@@ -3132,7 +3132,7 @@ inline auto runtime(string_view s) -> runtime_format_string<> {
 }
 #endif
 
-FMT_API auto vformat(string_view fmt, format_args args) -> efp::String;
+EFP_FMT_API auto vformat(string_view fmt, format_args args) -> efp::String;
 
 /**
   \rst
@@ -3146,12 +3146,12 @@ FMT_API auto vformat(string_view fmt, format_args args) -> efp::String;
   \endrst
 */
 template<typename... T>
-FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args) -> efp::String {
+EFP_FMT_NODISCARD EFP_FMT_INLINE auto format(format_string<T...> fmt, T&&... args) -> efp::String {
     return vformat(fmt, efp_fmt::make_format_args(args...));
 }
 
 /** Formats a string and writes the output to ``out``. */
-template<typename OutputIt, FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
+template<typename OutputIt, EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 auto vformat_to(OutputIt out, string_view fmt, format_args args) -> OutputIt {
     auto&& buf = detail::get_buffer<char>(out);
     detail::vformat_to(buf, fmt, args, {});
@@ -3173,8 +3173,8 @@ auto vformat_to(OutputIt out, string_view fmt, format_args args) -> OutputIt {
 template<
     typename OutputIt,
     typename... T,
-    FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
-FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args) -> OutputIt {
+    EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
+EFP_FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args) -> OutputIt {
     return vformat_to(out, fmt, efp_fmt::make_format_args(args...));
 }
 
@@ -3189,7 +3189,7 @@ struct format_to_n_result {
 template<
     typename OutputIt,
     typename... T,
-    FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
+    EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 auto vformat_to_n(OutputIt out, size_t n, string_view fmt, format_args args)
     -> format_to_n_result<OutputIt> {
     using traits = detail::fixed_buffer_traits;
@@ -3209,22 +3209,22 @@ auto vformat_to_n(OutputIt out, size_t n, string_view fmt, format_args args)
 template<
     typename OutputIt,
     typename... T,
-    FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
-FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt, T&&... args)
+    EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
+EFP_FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt, T&&... args)
     -> format_to_n_result<OutputIt> {
     return vformat_to_n(out, n, fmt, efp_fmt::make_format_args(args...));
 }
 
 /** Returns the number of chars in the output of ``format(fmt, args...)``. */
 template<typename... T>
-FMT_NODISCARD FMT_INLINE auto formatted_size(format_string<T...> fmt, T&&... args) -> size_t {
+EFP_FMT_NODISCARD EFP_FMT_INLINE auto formatted_size(format_string<T...> fmt, T&&... args) -> size_t {
     auto buf = detail::counting_buffer<>();
     detail::vformat_to<char>(buf, fmt, efp_fmt::make_format_args(args...), {});
     return buf.count();
 }
 
-FMT_API void vprint(string_view fmt, format_args args);
-FMT_API void vprint(std::FILE* f, string_view fmt, format_args args);
+EFP_FMT_API void vprint(string_view fmt, format_args args);
+EFP_FMT_API void vprint(std::FILE* f, string_view fmt, format_args args);
 
 /**
   \rst
@@ -3237,7 +3237,7 @@ FMT_API void vprint(std::FILE* f, string_view fmt, format_args args);
   \endrst
  */
 template<typename... T>
-FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
+EFP_FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
     const auto& vargs = efp_fmt::make_format_args(args...);
     return detail::is_utf8() ? vprint(fmt, vargs) : detail::vprint_mojibake(stdout, fmt, vargs);
 }
@@ -3253,7 +3253,7 @@ FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
   \endrst
  */
 template<typename... T>
-FMT_INLINE void print(std::FILE* f, format_string<T...> fmt, T&&... args) {
+EFP_FMT_INLINE void print(std::FILE* f, format_string<T...> fmt, T&&... args) {
     const auto& vargs = efp_fmt::make_format_args(args...);
     return detail::is_utf8() ? vprint(f, fmt, vargs) : detail::vprint_mojibake(f, fmt, vargs);
 }
@@ -3263,7 +3263,7 @@ FMT_INLINE void print(std::FILE* f, format_string<T...> fmt, T&&... args) {
   output to the file ``f`` followed by a newline.
  */
 template<typename... T>
-FMT_INLINE void println(std::FILE* f, format_string<T...> fmt, T&&... args) {
+EFP_FMT_INLINE void println(std::FILE* f, format_string<T...> fmt, T&&... args) {
     return efp_fmt::print(f, "{}\n", efp_fmt::format(fmt, std::forward<T>(args)...));
 }
 
@@ -3272,15 +3272,15 @@ FMT_INLINE void println(std::FILE* f, format_string<T...> fmt, T&&... args) {
   to ``stdout`` followed by a newline.
  */
 template<typename... T>
-FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
+EFP_FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
     return efp_fmt::println(stdout, fmt, std::forward<T>(args)...);
 }
 
-FMT_END_EXPORT
-FMT_GCC_PRAGMA("GCC pop_options")
-FMT_END_NAMESPACE
+EFP_FMT_END_EXPORT
+EFP_FMT_GCC_PRAGMA("GCC pop_options")
+EFP_FMT_END_NAMESPACE
 
-#ifdef FMT_HEADER_ONLY
+#ifdef EFP_FMT_HEADER_ONLY
     #include "format.h"
 #endif
 #endif  // EFP_FMT_CORE_H_

--- a/include/efp/fmt/core.h
+++ b/include/efp/fmt/core.h
@@ -171,7 +171,7 @@
 
 #ifndef FMT_BEGIN_NAMESPACE
     #define FMT_BEGIN_NAMESPACE \
-        namespace fmt { \
+        namespace efp_fmt { \
         inline namespace v10 {
     #define FMT_END_NAMESPACE \
         } \
@@ -333,12 +333,12 @@ FMT_NORETURN FMT_API void assert_fail(const char* file, int line, const char* me
 #ifndef FMT_ASSERT
     #ifdef NDEBUG
         // FMT_ASSERT is not empty to avoid -Wempty-body.
-        #define FMT_ASSERT(condition, message) fmt::detail::ignore_unused((condition), (message))
+        #define FMT_ASSERT(condition, message) efp_fmt::detail::ignore_unused((condition), (message))
     #else
         #define FMT_ASSERT(condition, message) \
             ((condition) /* void() fails with -Winvalid-constexpr on clang 4.0.1 */ \
                  ? (void)0 \
-                 : fmt::detail::assert_fail(__FILE__, __LINE__, (message)))
+                 : efp_fmt::detail::assert_fail(__FILE__, __LINE__, (message)))
     #endif
 #endif
 
@@ -397,7 +397,7 @@ FMT_CONSTEXPR inline auto is_utf8() -> bool {
 
 /**
   An implementation of ``efp::BasicStringView`` for pre-C++17. It provides a
-  subset of the API. ``fmt::basic_string_view`` is used for format strings even
+  subset of the API. ``efp_fmt::basic_string_view`` is used for format strings even
   if ``efp::String_view`` is available to prevent issues when a library is
   compiled with a different ``-std`` option than the client code (which is not
   recommended).
@@ -568,7 +568,7 @@ constexpr auto to_string_view(const S& s) -> basic_string_view<typename S::char_
 
 void to_string_view(...);
 
-// Specifies whether S is a string type convertible to fmt::basic_string_view.
+// Specifies whether S is a string type convertible to efp_fmt::basic_string_view.
 // It should be a constexpr function but MSVC 2017 fails to compile it in
 // enable_if and MSVC 2015 fails to compile it as an alias template.
 // ADL is intentionally disabled as to_string_view is not an extension point.
@@ -847,7 +847,7 @@ FMT_CONSTEXPR auto copy_str(T* begin, T* end, U* out) -> U* {
 /**
   \rst
   A contiguous memory buffer with an optional growing ability. It is an internal
-  class and shouldn't be used directly, only via `~fmt::basic_memory_buffer`.
+  class and shouldn't be used directly, only via `~efp_fmt::basic_memory_buffer`.
   \endrst
  */
 template<typename T>
@@ -1729,7 +1729,7 @@ auto copy_str(InputIt begin, InputIt end, std::back_insert_iterator<efp::String>
     // ! temp
     // efp::DebugType<std::back_insert_iterator<efp::String>> {};
     // efp::DebugType<decltype(get_container(out))> {};
-    // error: implicit instantiation of undefined template 'efp::DebugType<fmt::detail::buffer<char> &>'
+    // error: implicit instantiation of undefined template 'efp::DebugType<efp_fmt::detail::buffer<char> &>'
     get_container(out).append(begin, end);
     return out;
 }
@@ -2038,8 +2038,8 @@ using is_formattable = efp::Bool<!std::is_base_of<
 /**
   \rst
   An array of references to arguments. It can be implicitly converted into
-  `~fmt::basic_format_args` for passing into type-erased formatting functions
-  such as `~fmt::vformat`.
+  `~efp_fmt::basic_format_args` for passing into type-erased formatting functions
+  such as `~efp_fmt::vformat`.
   \endrst
  */
 template<typename Context, typename... Args>
@@ -2081,10 +2081,10 @@ public:
 
 /**
   \rst
-  Constructs a `~fmt::format_arg_store` object that contains references to
-  arguments and can be implicitly converted to `~fmt::format_args`. `Context`
-  can be omitted in which case it defaults to `~fmt::format_context`.
-  See `~fmt::arg` for lifetime considerations.
+  Constructs a `~efp_fmt::format_arg_store` object that contains references to
+  arguments and can be implicitly converted to `~efp_fmt::format_args`. `Context`
+  can be omitted in which case it defaults to `~efp_fmt::format_context`.
+  See `~efp_fmt::arg` for lifetime considerations.
   \endrst
  */
 // Arguments are taken by lvalue references to avoid some lifetime issues.
@@ -2101,7 +2101,7 @@ constexpr auto make_format_args(T&... args) -> format_arg_store<Context, efp::CV
 
   **Example**::
 
-    fmt::print("Elapsed time: {s:.2f} seconds", fmt::arg("s", 1.23));
+    efp_fmt::print("Elapsed time: {s:.2f} seconds", efp_fmt::arg("s", 1.23));
   \endrst
  */
 template<typename Char, typename T>
@@ -2171,7 +2171,7 @@ public:
 
     /**
    \rst
-   Constructs a `basic_format_args` object from `~fmt::format_arg_store`.
+   Constructs a `basic_format_args` object from `~efp_fmt::format_arg_store`.
    \endrst
    */
     template<typename... Args>
@@ -2181,7 +2181,7 @@ public:
     /**
    \rst
    Constructs a `basic_format_args` object from
-   `~fmt::dynamic_format_arg_store`.
+   `~efp_fmt::dynamic_format_arg_store`.
    \endrst
    */
     constexpr FMT_INLINE basic_format_args(const dynamic_format_arg_store<Context>& store)
@@ -3124,7 +3124,7 @@ using format_string = basic_format_string<char, type_identity_t<Args>...>;
   **Example**::
 
     // Check format string at runtime instead of compile-time.
-    fmt::print(fmt::runtime("{:d}"), "I am not a number");
+    efp_fmt::print(efp_fmt::runtime("{:d}"), "I am not a number");
   \endrst
  */
 inline auto runtime(string_view s) -> runtime_format_string<> {
@@ -3142,12 +3142,12 @@ FMT_API auto vformat(string_view fmt, format_args args) -> efp::String;
   **Example**::
 
     #include <fmt/core.h>
-    efp::String message = fmt::format("The answer is {}.", 42);
+    efp::String message = efp_fmt::format("The answer is {}.", 42);
   \endrst
 */
 template<typename... T>
 FMT_NODISCARD FMT_INLINE auto format(format_string<T...> fmt, T&&... args) -> efp::String {
-    return vformat(fmt, fmt::make_format_args(args...));
+    return vformat(fmt, efp_fmt::make_format_args(args...));
 }
 
 /** Formats a string and writes the output to ``out``. */
@@ -3167,7 +3167,7 @@ auto vformat_to(OutputIt out, string_view fmt, format_args args) -> OutputIt {
  **Example**::
 
    auto out = std::vector<char>();
-   fmt::format_to(std::back_inserter(out), "{}", 42);
+   efp_fmt::format_to(std::back_inserter(out), "{}", 42);
  \endrst
  */
 template<
@@ -3175,7 +3175,7 @@ template<
     typename... T,
     FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 FMT_INLINE auto format_to(OutputIt out, format_string<T...> fmt, T&&... args) -> OutputIt {
-    return vformat_to(out, fmt, fmt::make_format_args(args...));
+    return vformat_to(out, fmt, efp_fmt::make_format_args(args...));
 }
 
 template<typename OutputIt>
@@ -3212,14 +3212,14 @@ template<
     FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value)>
 FMT_INLINE auto format_to_n(OutputIt out, size_t n, format_string<T...> fmt, T&&... args)
     -> format_to_n_result<OutputIt> {
-    return vformat_to_n(out, n, fmt, fmt::make_format_args(args...));
+    return vformat_to_n(out, n, fmt, efp_fmt::make_format_args(args...));
 }
 
 /** Returns the number of chars in the output of ``format(fmt, args...)``. */
 template<typename... T>
 FMT_NODISCARD FMT_INLINE auto formatted_size(format_string<T...> fmt, T&&... args) -> size_t {
     auto buf = detail::counting_buffer<>();
-    detail::vformat_to<char>(buf, fmt, fmt::make_format_args(args...), {});
+    detail::vformat_to<char>(buf, fmt, efp_fmt::make_format_args(args...), {});
     return buf.count();
 }
 
@@ -3233,12 +3233,12 @@ FMT_API void vprint(std::FILE* f, string_view fmt, format_args args);
 
   **Example**::
 
-    fmt::print("Elapsed time: {0:.2f} seconds", 1.23);
+    efp_fmt::print("Elapsed time: {0:.2f} seconds", 1.23);
   \endrst
  */
 template<typename... T>
 FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
-    const auto& vargs = fmt::make_format_args(args...);
+    const auto& vargs = efp_fmt::make_format_args(args...);
     return detail::is_utf8() ? vprint(fmt, vargs) : detail::vprint_mojibake(stdout, fmt, vargs);
 }
 
@@ -3249,12 +3249,12 @@ FMT_INLINE void print(format_string<T...> fmt, T&&... args) {
 
   **Example**::
 
-    fmt::print(stderr, "Don't {}!", "panic");
+    efp_fmt::print(stderr, "Don't {}!", "panic");
   \endrst
  */
 template<typename... T>
 FMT_INLINE void print(std::FILE* f, format_string<T...> fmt, T&&... args) {
-    const auto& vargs = fmt::make_format_args(args...);
+    const auto& vargs = efp_fmt::make_format_args(args...);
     return detail::is_utf8() ? vprint(f, fmt, vargs) : detail::vprint_mojibake(f, fmt, vargs);
 }
 
@@ -3264,7 +3264,7 @@ FMT_INLINE void print(std::FILE* f, format_string<T...> fmt, T&&... args) {
  */
 template<typename... T>
 FMT_INLINE void println(std::FILE* f, format_string<T...> fmt, T&&... args) {
-    return fmt::print(f, "{}\n", fmt::format(fmt, std::forward<T>(args)...));
+    return efp_fmt::print(f, "{}\n", efp_fmt::format(fmt, std::forward<T>(args)...));
 }
 
 /**
@@ -3273,7 +3273,7 @@ FMT_INLINE void println(std::FILE* f, format_string<T...> fmt, T&&... args) {
  */
 template<typename... T>
 FMT_INLINE void println(format_string<T...> fmt, T&&... args) {
-    return fmt::println(stdout, fmt, std::forward<T>(args)...);
+    return efp_fmt::println(stdout, fmt, std::forward<T>(args)...);
 }
 
 FMT_END_EXPORT

--- a/include/efp/fmt/format-inl.h
+++ b/include/efp/fmt/format-inl.h
@@ -1438,7 +1438,7 @@ FMT_FUNC void report_system_error(int error_code, const char* message) noexcept 
 
 FMT_FUNC efp::String vformat(string_view fmt, format_args args) {
     // Don't optimize the "{}" case to keep the binary size small and because it
-    // can be better optimized in fmt::format anyway.
+    // can be better optimized in efp_fmt::format anyway.
     auto buffer = memory_buffer();
     detail::vformat_to(buffer, fmt, args);
     return to_string(buffer);

--- a/include/efp/fmt/format-inl.h
+++ b/include/efp/fmt/format-inl.h
@@ -5,8 +5,8 @@
 //
 // For the license information refer to format.h.
 
-#ifndef FMT_FORMAT_INL_H_
-#define FMT_FORMAT_INL_H_
+#ifndef EFP_FMT_FORMAT_INL_H_
+#define EFP_FMT_FORMAT_INL_H_
 
 #include <algorithm>
 #include <cerrno>  // errno
@@ -14,21 +14,21 @@
 #include <cmath>
 #include <exception>
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#ifndef EFP_FMT_STATIC_THOUSANDS_SEPARATOR
     #include <locale>
 #endif
 
-#if defined(_WIN32) && !defined(FMT_WINDOWS_NO_WCHAR)
+#if defined(_WIN32) && !defined(EFP_FMT_WINDOWS_NO_WCHAR)
     #include <io.h>  // _isatty
 #endif
 
 #include "format.h"
 
-FMT_BEGIN_NAMESPACE
+EFP_FMT_BEGIN_NAMESPACE
 
 namespace detail {
 
-FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
+EFP_FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
     // Use unchecked std::fprintf to avoid triggering another assertion when
     // writing to stderr fails
     std::fprintf(stderr, "%s:%d: assertion failed: %s", file, line, message);
@@ -37,11 +37,11 @@ FMT_FUNC void assert_fail(const char* file, int line, const char* message) {
     std::terminate();
 }
 
-FMT_FUNC void throw_format_error(const char* message) {
-    FMT_THROW(format_error(message));
+EFP_FMT_FUNC void throw_format_error(const char* message) {
+    EFP_FMT_THROW(format_error(message));
 }
 
-FMT_FUNC void
+EFP_FMT_FUNC void
 format_error_code(detail::buffer<char>& out, int error_code, string_view message) noexcept {
     // Report error code making sure that the output fits into
     // inline_buffer_size to avoid dynamic memory allocation and potential
@@ -59,12 +59,12 @@ format_error_code(detail::buffer<char>& out, int error_code, string_view message
     error_code_size += detail::to_unsigned(detail::count_digits(abs_value));
     auto it = buffer_appender<char>(out);
     if (message.size() <= inline_buffer_size - error_code_size)
-        format_to(it, FMT_STRING("{}{}"), message, SEP);
-    format_to(it, FMT_STRING("{}{}"), ERROR_STR, error_code);
-    FMT_ASSERT(out.size() <= inline_buffer_size, "");
+        format_to(it, EFP_FMT_STRING("{}{}"), message, SEP);
+    format_to(it, EFP_FMT_STRING("{}{}"), ERROR_STR, error_code);
+    EFP_FMT_ASSERT(out.size() <= inline_buffer_size, "");
 }
 
-FMT_FUNC void report_error(format_func func, int error_code, const char* message) noexcept {
+EFP_FMT_FUNC void report_error(format_func func, int error_code, const char* message) noexcept {
     memory_buffer full_message;
     func(full_message, error_code, message);
     // Don't use fwrite_fully because the latter may throw.
@@ -76,10 +76,10 @@ FMT_FUNC void report_error(format_func func, int error_code, const char* message
 inline void fwrite_fully(const void* ptr, size_t count, FILE* stream) {
     size_t written = std::fwrite(ptr, 1, count, stream);
     if (written < count)
-        FMT_THROW(system_error(errno, FMT_STRING("cannot write to file")));
+        EFP_FMT_THROW(system_error(errno, EFP_FMT_STRING("cannot write to file")));
 }
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#ifndef EFP_FMT_STATIC_THOUSANDS_SEPARATOR
 template<typename Locale>
 locale_ref::locale_ref(const Locale& loc) : locale_(&loc) {
     static_assert(efp::IsSame<Locale, std::locale>::value, "");
@@ -92,7 +92,7 @@ Locale locale_ref::get() const {
 }
 
 template<typename Char>
-FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
+EFP_FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
     auto& facet = std::use_facet<std::numpunct<Char>>(loc.get<std::locale>());
     auto grouping = facet.grouping();
     auto thousands_sep = grouping.empty() ? Char() : facet.thousands_sep();
@@ -100,24 +100,24 @@ FMT_FUNC auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char> {
 }
 
 template<typename Char>
-FMT_FUNC Char decimal_point_impl(locale_ref loc) {
+EFP_FMT_FUNC Char decimal_point_impl(locale_ref loc) {
     return std::use_facet<std::numpunct<Char>>(loc.get<std::locale>()).decimal_point();
 }
 #else
 template<typename Char>
-FMT_FUNC auto thousands_sep_impl(locale_ref) -> thousands_sep_result<Char> {
-    return {"\03", FMT_STATIC_THOUSANDS_SEPARATOR};
+EFP_FMT_FUNC auto thousands_sep_impl(locale_ref) -> thousands_sep_result<Char> {
+    return {"\03", EFP_FMT_STATIC_THOUSANDS_SEPARATOR};
 }
 
 template<typename Char>
-FMT_FUNC Char decimal_point_impl(locale_ref) {
+EFP_FMT_FUNC Char decimal_point_impl(locale_ref) {
     return '.';
 }
 #endif
 
-FMT_FUNC auto write_loc(appender out, loc_value value, const format_specs<>& specs, locale_ref loc)
+EFP_FMT_FUNC auto write_loc(appender out, loc_value value, const format_specs<>& specs, locale_ref loc)
     -> bool {
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#ifndef EFP_FMT_STATIC_THOUSANDS_SEPARATOR
     auto locale = loc.get<std::locale>();
     // We cannot use the num_put<char> facet because it may produce output in
     // a wrong encoding.
@@ -133,7 +133,7 @@ FMT_FUNC auto write_loc(appender out, loc_value value, const format_specs<>& spe
 template<typename Locale>
 typename Locale::id format_facet<Locale>::id;
 
-#ifndef FMT_STATIC_THOUSANDS_SEPARATOR
+#ifndef EFP_FMT_STATIC_THOUSANDS_SEPARATOR
 template<typename Locale>
 format_facet<Locale>::format_facet(Locale& loc) {
     auto& numpunct = std::use_facet<std::numpunct<char>>(loc);
@@ -143,14 +143,14 @@ format_facet<Locale>::format_facet(Locale& loc) {
 }
 
 template<>
-FMT_API FMT_FUNC auto
+EFP_FMT_API EFP_FMT_FUNC auto
 format_facet<std::locale>::do_put(appender out, loc_value val, const format_specs<>& specs) const
     -> bool {
     return val.visit(detail::loc_writer<> {out, specs, separator_, grouping_, decimal_point_});
 }
 #endif
 
-FMT_FUNC std::system_error vsystem_error(int error_code, string_view fmt, format_args args) {
+EFP_FMT_FUNC std::system_error vsystem_error(int error_code, string_view fmt, format_args args) {
     auto ec = std::error_code(error_code, std::generic_category());
     return std::system_error(ec, vformat(fmt, args));
 }
@@ -163,12 +163,12 @@ inline bool operator==(basic_fp<F> x, basic_fp<F> y) {
 }
 
 // Compilers should be able to optimize this into the ror instruction.
-FMT_CONSTEXPR inline uint32_t rotr(uint32_t n, uint32_t r) noexcept {
+EFP_FMT_CONSTEXPR inline uint32_t rotr(uint32_t n, uint32_t r) noexcept {
     r &= 31;
     return (n >> r) | (n << (32 - r));
 }
 
-FMT_CONSTEXPR inline uint64_t rotr(uint64_t n, uint32_t r) noexcept {
+EFP_FMT_CONSTEXPR inline uint64_t rotr(uint64_t n, uint32_t r) noexcept {
     r &= 63;
     return (n >> r) | (n << (64 - r));
 }
@@ -197,11 +197,11 @@ namespace dragonbox {
 
     // Various fast log computations.
     inline int floor_log10_pow2_minus_log10_4_over_3(int e) noexcept {
-        FMT_ASSERT(e <= 2936 && e >= -2985, "too large exponent");
+        EFP_FMT_ASSERT(e <= 2936 && e >= -2985, "too large exponent");
         return (e * 631305 - 261663) >> 21;
     }
 
-    FMT_INLINE_VARIABLE constexpr struct {
+    EFP_FMT_INLINE_VARIABLE constexpr struct {
         uint32_t divisor;
         int shift_amount;
     } div_small_pow10_infos[] = {{10, 16}, {100, 16}};
@@ -223,7 +223,7 @@ namespace dragonbox {
         // to ceil(2^k/d) for large enough k.
         // The idea for item 2 originates from Schubfach.
         constexpr auto info = div_small_pow10_infos[N - 1];
-        FMT_ASSERT(n <= info.divisor * 10, "n is too large");
+        EFP_FMT_ASSERT(n <= info.divisor * 10, "n is too large");
         constexpr uint32_t magic_number = (1u << info.shift_amount) / info.divisor + 1;
         n *= magic_number;
         const uint32_t comparison_mask = (1u << info.shift_amount) - 1;
@@ -237,7 +237,7 @@ namespace dragonbox {
     template<int N>
     uint32_t small_division_by_pow10(uint32_t n) noexcept {
         constexpr auto info = div_small_pow10_infos[N - 1];
-        FMT_ASSERT(n <= info.divisor * 10, "n is too large");
+        EFP_FMT_ASSERT(n <= info.divisor * 10, "n is too large");
         constexpr uint32_t magic_number = (1u << info.shift_amount) / info.divisor + 1;
         return (n * magic_number) >> info.shift_amount;
     }
@@ -264,7 +264,7 @@ namespace dragonbox {
         using cache_entry_type = uint64_t;
 
         static uint64_t get_cached_power(int k) noexcept {
-            FMT_ASSERT(
+            EFP_FMT_ASSERT(
                 k >= float_info<float>::min_k && k <= float_info<float>::max_k,
                 "k is out of range"
             );
@@ -315,8 +315,8 @@ namespace dragonbox {
 
         static compute_mul_parity_result
         compute_mul_parity(carrier_uint two_f, const cache_entry_type& cache, int beta) noexcept {
-            FMT_ASSERT(beta >= 1, "");
-            FMT_ASSERT(beta < 64, "");
+            EFP_FMT_ASSERT(beta >= 1, "");
+            EFP_FMT_ASSERT(beta < 64, "");
 
             auto r = umul96_lower64(two_f, cache);
             return {((r >> (64 - beta)) & 1) != 0, static_cast<uint32_t>(r >> (32 - beta)) == 0};
@@ -360,13 +360,13 @@ namespace dragonbox {
         using cache_entry_type = uint128_fallback;
 
         static uint128_fallback get_cached_power(int k) noexcept {
-            FMT_ASSERT(
+            EFP_FMT_ASSERT(
                 k >= float_info<double>::min_k && k <= float_info<double>::max_k,
                 "k is out of range"
             );
 
             static constexpr const uint128_fallback pow10_significands[] = {
-#if FMT_USE_FULL_CACHE_DRAGONBOX
+#if EFP_FMT_USE_FULL_CACHE_DRAGONBOX
                 {0xff77b1fcbebcdc4f, 0x25e8e89c13bb0f7b},
                 {0x9faacf3df73609b1, 0x77b191618c54e9ad},
                 {0xc795830d75038c1d, 0xd59df5b9ef6a2418},
@@ -1030,7 +1030,7 @@ namespace dragonbox {
 #endif
             };
 
-#if FMT_USE_FULL_CACHE_DRAGONBOX
+#if EFP_FMT_USE_FULL_CACHE_DRAGONBOX
             return pow10_significands[k - float_info<double>::min_k];
 #else
             static constexpr const uint64_t powers_of_5_64[] = {
@@ -1057,7 +1057,7 @@ namespace dragonbox {
 
             // Compute the required amount of bit-shift.
             int alpha = floor_log2_pow10(kb + offset) - floor_log2_pow10(kb) - offset;
-            FMT_ASSERT(alpha > 0 && alpha < 64, "shifting error detected");
+            EFP_FMT_ASSERT(alpha > 0 && alpha < 64, "shifting error detected");
 
             // Try to recover the real cache.
             uint64_t pow5 = powers_of_5_64[offset];
@@ -1073,7 +1073,7 @@ namespace dragonbox {
                 (recovered_cache.low() >> alpha) | high_to_middle,
                 ((middle_low.low() >> alpha) | middle_to_low)
             };
-            FMT_ASSERT(recovered_cache.low() + 1 != 0, "");
+            EFP_FMT_ASSERT(recovered_cache.low() + 1 != 0, "");
             return {recovered_cache.high(), recovered_cache.low() + 1};
 #endif
         }
@@ -1100,8 +1100,8 @@ namespace dragonbox {
 
         static compute_mul_parity_result
         compute_mul_parity(carrier_uint two_f, const cache_entry_type& cache, int beta) noexcept {
-            FMT_ASSERT(beta >= 1, "");
-            FMT_ASSERT(beta < 64, "");
+            EFP_FMT_ASSERT(beta >= 1, "");
+            EFP_FMT_ASSERT(beta < 64, "");
 
             auto r = umul192_lower128(two_f, cache);
             return {
@@ -1134,7 +1134,7 @@ namespace dragonbox {
         }
     };
 
-    FMT_FUNC uint128_fallback get_cached_power(int k) noexcept {
+    EFP_FMT_FUNC uint128_fallback get_cached_power(int k) noexcept {
         return cache_accessor<double>::get_cached_power(k);
     }
 
@@ -1148,8 +1148,8 @@ namespace dragonbox {
     }
 
     // Remove trailing zeros from n and return the number of zeros removed (float)
-    FMT_INLINE int remove_trailing_zeros(uint32_t& n, int s = 0) noexcept {
-        FMT_ASSERT(n != 0, "");
+    EFP_FMT_INLINE int remove_trailing_zeros(uint32_t& n, int s = 0) noexcept {
+        EFP_FMT_ASSERT(n != 0, "");
         // Modular inverse of 5 (mod 2^32): (mod_inv_5 * 5) mod 2^32 = 1.
         constexpr uint32_t mod_inv_5 = 0xcccccccd;
         constexpr uint32_t mod_inv_25 = 0xc28f5c29;  // = mod_inv_5 * mod_inv_5
@@ -1170,8 +1170,8 @@ namespace dragonbox {
     }
 
     // Removes trailing zeros and returns the number of zeros removed (double)
-    FMT_INLINE int remove_trailing_zeros(uint64_t& n) noexcept {
-        FMT_ASSERT(n != 0, "");
+    EFP_FMT_INLINE int remove_trailing_zeros(uint64_t& n) noexcept {
+        EFP_FMT_ASSERT(n != 0, "");
 
         // This magic number is ceil(2^90 / 10^8).
         constexpr uint64_t magic_number = 12379400392853802749ull;
@@ -1210,7 +1210,7 @@ namespace dragonbox {
 
     // The main algorithm for shorter interval case
     template<typename T>
-    FMT_INLINE decimal_fp<T> shorter_interval_case(int exponent) noexcept {
+    EFP_FMT_INLINE decimal_fp<T> shorter_interval_case(int exponent) noexcept {
         decimal_fp<T> ret_value;
         // Compute k and beta
         const int minus_k = floor_log10_pow2_minus_log10_4_over_3(exponent);
@@ -1383,7 +1383,7 @@ namespace dragonbox {
 
 template<>
 struct formatter<detail::bigint> {
-    FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> format_parse_context::iterator {
+    EFP_FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> format_parse_context::iterator {
         return ctx.begin();
     }
 
@@ -1393,22 +1393,22 @@ struct formatter<detail::bigint> {
         for (auto i = n.bigits_.size(); i > 0; --i) {
             auto value = n.bigits_[i - 1u];
             if (first) {
-                out = format_to(out, FMT_STRING("{:x}"), value);
+                out = format_to(out, EFP_FMT_STRING("{:x}"), value);
                 first = false;
                 continue;
             }
-            out = format_to(out, FMT_STRING("{:08x}"), value);
+            out = format_to(out, EFP_FMT_STRING("{:08x}"), value);
         }
         if (n.exp_ > 0)
-            out = format_to(out, FMT_STRING("p{}"), n.exp_ * detail::bigint::bigit_bits);
+            out = format_to(out, EFP_FMT_STRING("p{}"), n.exp_ * detail::bigint::bigit_bits);
         return out;
     }
 };
 
-FMT_FUNC detail::utf8_to_utf16::utf8_to_utf16(string_view s) {
+EFP_FMT_FUNC detail::utf8_to_utf16::utf8_to_utf16(string_view s) {
     for_each_codepoint(s, [this](uint32_t cp, string_view) {
         if (cp == invalid_code_point)
-            FMT_THROW(std::runtime_error("invalid utf8"));
+            EFP_FMT_THROW(std::runtime_error("invalid utf8"));
         if (cp <= 0xFFFF) {
             buffer_.push_back(static_cast<wchar_t>(cp));
         } else {
@@ -1421,22 +1421,22 @@ FMT_FUNC detail::utf8_to_utf16::utf8_to_utf16(string_view s) {
     buffer_.push_back(0);
 }
 
-FMT_FUNC void
+EFP_FMT_FUNC void
 format_system_error(detail::buffer<char>& out, int error_code, const char* message) noexcept {
-    FMT_TRY {
+    EFP_FMT_TRY {
         auto ec = std::error_code(error_code, std::generic_category());
         write(std::back_inserter(out), std::system_error(ec, message).what());
         return;
     }
-    FMT_CATCH(...) {}
+    EFP_FMT_CATCH(...) {}
     format_error_code(out, error_code, message);
 }
 
-FMT_FUNC void report_system_error(int error_code, const char* message) noexcept {
+EFP_FMT_FUNC void report_system_error(int error_code, const char* message) noexcept {
     report_error(format_system_error, error_code, message);
 }
 
-FMT_FUNC efp::String vformat(string_view fmt, format_args args) {
+EFP_FMT_FUNC efp::String vformat(string_view fmt, format_args args) {
     // Don't optimize the "{}" case to keep the binary size small and because it
     // can be better optimized in efp_fmt::format anyway.
     auto buffer = memory_buffer();
@@ -1445,8 +1445,8 @@ FMT_FUNC efp::String vformat(string_view fmt, format_args args) {
 }
 
 namespace detail {
-#if !defined(_WIN32) || defined(FMT_WINDOWS_NO_WCHAR)
-FMT_FUNC bool write_console(int, string_view) {
+#if !defined(_WIN32) || defined(EFP_FMT_WINDOWS_NO_WCHAR)
+EFP_FMT_FUNC bool write_console(int, string_view) {
     return false;
 }
 #else
@@ -1454,7 +1454,7 @@ using dword = efp::Conditional<sizeof(long) == 4, unsigned long, unsigned>;
 extern "C" __declspec(dllimport) int __stdcall WriteConsoleW(  //
     void*, const void*, dword, dword*, void*);
 
-FMT_FUNC bool write_console(int fd, string_view text) {
+EFP_FMT_FUNC bool write_console(int fd, string_view text) {
     auto u16 = utf8_to_utf16(text);
     return WriteConsoleW(
                reinterpret_cast<void*>(_get_osfhandle(fd)),
@@ -1469,14 +1469,14 @@ FMT_FUNC bool write_console(int fd, string_view text) {
 
 #ifdef _WIN32
 // Print assuming legacy (non-Unicode) encoding.
-FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args) {
+EFP_FMT_FUNC void vprint_mojibake(std::FILE* f, string_view fmt, format_args args) {
     auto buffer = memory_buffer();
     detail::vformat_to(buffer, fmt, args);
     fwrite_fully(buffer.data(), buffer.size(), f);
 }
 #endif
 
-FMT_FUNC void print(std::FILE* f, string_view text) {
+EFP_FMT_FUNC void print(std::FILE* f, string_view text) {
 #ifdef _WIN32
     int fd = _fileno(f);
     if (_isatty(fd)) {
@@ -1489,13 +1489,13 @@ FMT_FUNC void print(std::FILE* f, string_view text) {
 }
 }  // namespace detail
 
-FMT_FUNC void vprint(std::FILE* f, string_view fmt, format_args args) {
+EFP_FMT_FUNC void vprint(std::FILE* f, string_view fmt, format_args args) {
     auto buffer = memory_buffer();
     detail::vformat_to(buffer, fmt, args);
     detail::print(f, {buffer.data(), buffer.size()});
 }
 
-FMT_FUNC void vprint(string_view fmt, format_args args) {
+EFP_FMT_FUNC void vprint(string_view fmt, format_args args) {
     vprint(stdout, fmt, args);
 }
 
@@ -1544,7 +1544,7 @@ inline auto is_printable(
 }
 
 // This code is generated by support/printable.py.
-FMT_FUNC auto is_printable(uint32_t cp) -> bool {
+EFP_FMT_FUNC auto is_printable(uint32_t cp) -> bool {
     static constexpr singleton singletons0[] = {
         {0x00, 1},  {0x03, 5},  {0x05, 6},  {0x06, 3},  {0x07, 6},  {0x08, 8}, {0x09, 17},
         {0x0a, 28}, {0x0b, 25}, {0x0c, 20}, {0x0d, 16}, {0x0e, 13}, {0x0f, 4}, {0x10, 3},
@@ -1691,6 +1691,6 @@ FMT_FUNC auto is_printable(uint32_t cp) -> bool {
 
 }  // namespace detail
 
-FMT_END_NAMESPACE
+EFP_FMT_END_NAMESPACE
 
-#endif  // FMT_FORMAT_INL_H_
+#endif  // EFP_FMT_FORMAT_INL_H_

--- a/include/efp/fmt/format.h
+++ b/include/efp/fmt/format.h
@@ -30,8 +30,8 @@
   without including the above copyright and permission notices.
  */
 
-#ifndef FMT_FORMAT_H_
-#define FMT_FORMAT_H_
+#ifndef EFP_FMT_FORMAT_H_
+#define EFP_FMT_FORMAT_H_
 
 #include <cmath>             // std::signbit
 #include <cstdint>           // uint32_t
@@ -49,72 +49,72 @@
 #include "core.h"
 
 #if defined __cpp_inline_variables && __cpp_inline_variables >= 201606L
-    #define FMT_INLINE_VARIABLE inline
+    #define EFP_FMT_INLINE_VARIABLE inline
 #else
-    #define FMT_INLINE_VARIABLE
+    #define EFP_FMT_INLINE_VARIABLE
 #endif
 
-#if FMT_HAS_CPP17_ATTRIBUTE(fallthrough)
-    #define FMT_FALLTHROUGH [[fallthrough]]
+#if EFP_FMT_HAS_CPP17_ATTRIBUTE(fallthrough)
+    #define EFP_FMT_FALLTHROUGH [[fallthrough]]
 #elif defined(__clang__)
-    #define FMT_FALLTHROUGH [[clang::fallthrough]]
-#elif FMT_GCC_VERSION >= 700 && (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
-    #define FMT_FALLTHROUGH [[gnu::fallthrough]]
+    #define EFP_FMT_FALLTHROUGH [[clang::fallthrough]]
+#elif EFP_FMT_GCC_VERSION >= 700 && (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= 520)
+    #define EFP_FMT_FALLTHROUGH [[gnu::fallthrough]]
 #else
-    #define FMT_FALLTHROUGH
+    #define EFP_FMT_FALLTHROUGH
 #endif
 
-#ifndef FMT_DEPRECATED
-    #if FMT_HAS_CPP14_ATTRIBUTE(deprecated) || FMT_MSC_VERSION >= 1900
-        #define FMT_DEPRECATED [[deprecated]]
+#ifndef EFP_FMT_DEPRECATED
+    #if EFP_FMT_HAS_CPP14_ATTRIBUTE(deprecated) || EFP_FMT_MSC_VERSION >= 1900
+        #define EFP_FMT_DEPRECATED [[deprecated]]
     #else
         #if (defined(__GNUC__) && !defined(__LCC__)) || defined(__clang__)
-            #define FMT_DEPRECATED __attribute__((deprecated))
-        #elif FMT_MSC_VERSION
-            #define FMT_DEPRECATED __declspec(deprecated)
+            #define EFP_FMT_DEPRECATED __attribute__((deprecated))
+        #elif EFP_FMT_MSC_VERSION
+            #define EFP_FMT_DEPRECATED __declspec(deprecated)
         #else
-            #define FMT_DEPRECATED /* deprecated */
+            #define EFP_FMT_DEPRECATED /* deprecated */
         #endif
     #endif
 #endif
 
-#ifndef FMT_NO_UNIQUE_ADDRESS
-    #if FMT_CPLUSPLUS >= 202002L
-        #if FMT_HAS_CPP_ATTRIBUTE(no_unique_address)
-            #define FMT_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#ifndef EFP_FMT_NO_UNIQUE_ADDRESS
+    #if EFP_FMT_CPLUSPLUS >= 202002L
+        #if EFP_FMT_HAS_CPP_ATTRIBUTE(no_unique_address)
+            #define EFP_FMT_NO_UNIQUE_ADDRESS [[no_unique_address]]
         // VS2019 v16.10 and later except clang-cl (https://reviews.llvm.org/D110485)
-        #elif (FMT_MSC_VERSION >= 1929) && !FMT_CLANG_VERSION
-            #define FMT_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+        #elif (EFP_FMT_MSC_VERSION >= 1929) && !EFP_FMT_CLANG_VERSION
+            #define EFP_FMT_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
         #endif
     #endif
 #endif
-#ifndef FMT_NO_UNIQUE_ADDRESS
-    #define FMT_NO_UNIQUE_ADDRESS
+#ifndef EFP_FMT_NO_UNIQUE_ADDRESS
+    #define EFP_FMT_NO_UNIQUE_ADDRESS
 #endif
 
 // Visibility when compiled as a shared library/object.
-#if defined(FMT_LIB_EXPORT) || defined(FMT_SHARED)
-    #define FMT_SO_VISIBILITY(value) FMT_VISIBILITY(value)
+#if defined(EFP_FMT_LIB_EXPORT) || defined(EFP_FMT_SHARED)
+    #define EFP_FMT_SO_VISIBILITY(value) EFP_FMT_VISIBILITY(value)
 #else
-    #define FMT_SO_VISIBILITY(value)
+    #define EFP_FMT_SO_VISIBILITY(value)
 #endif
 
 #ifdef __has_builtin
-    #define FMT_HAS_BUILTIN(x) __has_builtin(x)
+    #define EFP_FMT_HAS_BUILTIN(x) __has_builtin(x)
 #else
-    #define FMT_HAS_BUILTIN(x) 0
+    #define EFP_FMT_HAS_BUILTIN(x) 0
 #endif
 
-#if FMT_GCC_VERSION || FMT_CLANG_VERSION
-    #define FMT_NOINLINE __attribute__((noinline))
+#if EFP_FMT_GCC_VERSION || EFP_FMT_CLANG_VERSION
+    #define EFP_FMT_NOINLINE __attribute__((noinline))
 #else
-    #define FMT_NOINLINE
+    #define EFP_FMT_NOINLINE
 #endif
 
-#ifndef FMT_THROW
-    #if FMT_EXCEPTIONS
-        #if FMT_MSC_VERSION || defined(__NVCC__)
-FMT_BEGIN_NAMESPACE
+#ifndef EFP_FMT_THROW
+    #if EFP_FMT_EXCEPTIONS
+        #if EFP_FMT_MSC_VERSION || defined(__NVCC__)
+EFP_FMT_BEGIN_NAMESPACE
 
 namespace detail {
 template<typename Exception>
@@ -127,86 +127,86 @@ inline void do_throw(const Exception& x) {
 }
 }  // namespace detail
 
-FMT_END_NAMESPACE
-            #define FMT_THROW(x) detail::do_throw(x)
+EFP_FMT_END_NAMESPACE
+            #define EFP_FMT_THROW(x) detail::do_throw(x)
         #else
-            #define FMT_THROW(x) throw x
+            #define EFP_FMT_THROW(x) throw x
         #endif
     #else
-        #define FMT_THROW(x) ::efp_fmt::detail::assert_fail(__FILE__, __LINE__, (x).what())
+        #define EFP_FMT_THROW(x) ::efp_fmt::detail::assert_fail(__FILE__, __LINE__, (x).what())
     #endif
 #endif
 
-#if FMT_EXCEPTIONS
-    #define FMT_TRY try
-    #define FMT_CATCH(x) catch (x)
+#if EFP_FMT_EXCEPTIONS
+    #define EFP_FMT_TRY try
+    #define EFP_FMT_CATCH(x) catch (x)
 #else
-    #define FMT_TRY if (true)
-    #define FMT_CATCH(x) if (false)
+    #define EFP_FMT_TRY if (true)
+    #define EFP_FMT_CATCH(x) if (false)
 #endif
 
-#ifndef FMT_MAYBE_UNUSED
-    #if FMT_HAS_CPP17_ATTRIBUTE(maybe_unused)
-        #define FMT_MAYBE_UNUSED [[maybe_unused]]
+#ifndef EFP_FMT_MAYBE_UNUSED
+    #if EFP_FMT_HAS_CPP17_ATTRIBUTE(maybe_unused)
+        #define EFP_FMT_MAYBE_UNUSED [[maybe_unused]]
     #else
-        #define FMT_MAYBE_UNUSED
+        #define EFP_FMT_MAYBE_UNUSED
     #endif
 #endif
 
-#ifndef FMT_USE_USER_DEFINED_LITERALS
+#ifndef EFP_FMT_USE_USER_DEFINED_LITERALS
     // EDG based compilers (Intel, NVIDIA, Elbrus, etc), GCC and MSVC support UDLs.
     //
     // GCC before 4.9 requires a space in `operator"" _a` which is invalid in later
     // compiler versions.
-    #if (FMT_HAS_FEATURE(cxx_user_literals) || FMT_GCC_VERSION >= 409 || FMT_MSC_VERSION >= 1900) \
+    #if (EFP_FMT_HAS_FEATURE(cxx_user_literals) || EFP_FMT_GCC_VERSION >= 409 || EFP_FMT_MSC_VERSION >= 1900) \
         && (!defined(__EDG_VERSION__) || __EDG_VERSION__ >= /* UDL feature */ 480)
-        #define FMT_USE_USER_DEFINED_LITERALS 1
+        #define EFP_FMT_USE_USER_DEFINED_LITERALS 1
     #else
-        #define FMT_USE_USER_DEFINED_LITERALS 0
+        #define EFP_FMT_USE_USER_DEFINED_LITERALS 0
     #endif
 #endif
 
-// Defining FMT_REDUCE_INT_INSTANTIATIONS to 1, will reduce the number of
+// Defining EFP_FMT_REDUCE_INT_INSTANTIATIONS to 1, will reduce the number of
 // integer formatter template instantiations to just one by only using the
 // largest integer type. This results in a reduction in binary size but will
 // cause a decrease in integer formatting performance.
-#if !defined(FMT_REDUCE_INT_INSTANTIATIONS)
-    #define FMT_REDUCE_INT_INSTANTIATIONS 0
+#if !defined(EFP_FMT_REDUCE_INT_INSTANTIATIONS)
+    #define EFP_FMT_REDUCE_INT_INSTANTIATIONS 0
 #endif
 
 // __builtin_clz is broken in clang with Microsoft CodeGen:
 // https://github.com/fmtlib/fmt/issues/519.
-#if !FMT_MSC_VERSION
-    #if FMT_HAS_BUILTIN(__builtin_clz) || FMT_GCC_VERSION || FMT_ICC_VERSION
-        #define FMT_BUILTIN_CLZ(n) __builtin_clz(n)
+#if !EFP_FMT_MSC_VERSION
+    #if EFP_FMT_HAS_BUILTIN(__builtin_clz) || EFP_FMT_GCC_VERSION || EFP_FMT_ICC_VERSION
+        #define EFP_FMT_BUILTIN_CLZ(n) __builtin_clz(n)
     #endif
-    #if FMT_HAS_BUILTIN(__builtin_clzll) || FMT_GCC_VERSION || FMT_ICC_VERSION
-        #define FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
+    #if EFP_FMT_HAS_BUILTIN(__builtin_clzll) || EFP_FMT_GCC_VERSION || EFP_FMT_ICC_VERSION
+        #define EFP_FMT_BUILTIN_CLZLL(n) __builtin_clzll(n)
     #endif
 #endif
 
 // __builtin_ctz is broken in Intel Compiler Classic on Windows:
 // https://github.com/fmtlib/fmt/issues/2510.
 #ifndef __ICL
-    #if FMT_HAS_BUILTIN(__builtin_ctz) || FMT_GCC_VERSION || FMT_ICC_VERSION \
+    #if EFP_FMT_HAS_BUILTIN(__builtin_ctz) || EFP_FMT_GCC_VERSION || EFP_FMT_ICC_VERSION \
         || defined(__NVCOMPILER)
-        #define FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
+        #define EFP_FMT_BUILTIN_CTZ(n) __builtin_ctz(n)
     #endif
-    #if FMT_HAS_BUILTIN(__builtin_ctzll) || FMT_GCC_VERSION || FMT_ICC_VERSION \
+    #if EFP_FMT_HAS_BUILTIN(__builtin_ctzll) || EFP_FMT_GCC_VERSION || EFP_FMT_ICC_VERSION \
         || defined(__NVCOMPILER)
-        #define FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
+        #define EFP_FMT_BUILTIN_CTZLL(n) __builtin_ctzll(n)
     #endif
 #endif
 
-#if FMT_MSC_VERSION
+#if EFP_FMT_MSC_VERSION
     #include <intrin.h>  // _BitScanReverse[64], _BitScanForward[64], _umul128
 #endif
 
 // Some compilers masquerade as both MSVC and GCC-likes or otherwise support
-// __builtin_clz and __builtin_clzll, so only define FMT_BUILTIN_CLZ using the
+// __builtin_clz and __builtin_clzll, so only define EFP_FMT_BUILTIN_CLZ using the
 // MSVC intrinsics if the clz and clzll builtins are not available.
-#if FMT_MSC_VERSION && !defined(FMT_BUILTIN_CLZLL) && !defined(FMT_BUILTIN_CTZLL)
-FMT_BEGIN_NAMESPACE
+#if EFP_FMT_MSC_VERSION && !defined(EFP_FMT_BUILTIN_CLZLL) && !defined(EFP_FMT_BUILTIN_CTZLL)
+EFP_FMT_BEGIN_NAMESPACE
 
 namespace detail {
     // Avoid Clang with Microsoft CodeGen's -Wunknown-pragmas warning.
@@ -222,15 +222,15 @@ namespace detail {
 inline auto clz(uint32_t x) -> int {
     unsigned long r = 0;
     _BitScanReverse(&r, x);
-    FMT_ASSERT(x != 0, "");
+    EFP_FMT_ASSERT(x != 0, "");
     // Static analysis complains about using uninitialized data
     // "r", but the only way that can happen is if "x" is 0,
     // which the callers guarantee to not happen.
-    FMT_MSC_WARNING(suppress : 6102)
+    EFP_FMT_MSC_WARNING(suppress : 6102)
     return 31 ^ static_cast<int>(r);
 }
 
-    #define FMT_BUILTIN_CLZ(n) detail::clz(n)
+    #define EFP_FMT_BUILTIN_CLZ(n) detail::clz(n)
 
 inline auto clzll(uint64_t x) -> int {
     unsigned long r = 0;
@@ -243,27 +243,27 @@ inline auto clzll(uint64_t x) -> int {
     // Scan the low 32 bits.
     _BitScanReverse(&r, static_cast<uint32_t>(x));
     #endif
-    FMT_ASSERT(x != 0, "");
-    FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
+    EFP_FMT_ASSERT(x != 0, "");
+    EFP_FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
     return 63 ^ static_cast<int>(r);
 }
 
-    #define FMT_BUILTIN_CLZLL(n) detail::clzll(n)
+    #define EFP_FMT_BUILTIN_CLZLL(n) detail::clzll(n)
 
 inline auto ctz(uint32_t x) -> int {
     unsigned long r = 0;
     _BitScanForward(&r, x);
-    FMT_ASSERT(x != 0, "");
-    FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
+    EFP_FMT_ASSERT(x != 0, "");
+    EFP_FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
     return static_cast<int>(r);
 }
 
-    #define FMT_BUILTIN_CTZ(n) detail::ctz(n)
+    #define EFP_FMT_BUILTIN_CTZ(n) detail::ctz(n)
 
 inline auto ctzll(uint64_t x) -> int {
     unsigned long r = 0;
-    FMT_ASSERT(x != 0, "");
-    FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
+    EFP_FMT_ASSERT(x != 0, "");
+    EFP_FMT_MSC_WARNING(suppress : 6102)  // Suppress a bogus static analysis warning.
     #ifdef _WIN64
     _BitScanForward64(&r, x);
     #else
@@ -277,13 +277,13 @@ inline auto ctzll(uint64_t x) -> int {
     return static_cast<int>(r);
 }
 
-    #define FMT_BUILTIN_CTZLL(n) detail::ctzll(n)
+    #define EFP_FMT_BUILTIN_CTZLL(n) detail::ctzll(n)
 }  // namespace detail
 
-FMT_END_NAMESPACE
+EFP_FMT_END_NAMESPACE
 #endif
 
-FMT_BEGIN_NAMESPACE
+EFP_FMT_BEGIN_NAMESPACE
 
 template<typename...>
 struct disjunction: efp::False {};
@@ -305,9 +305,9 @@ struct conjunction<P1, Pn...>: efp::Conditional<bool(P1::value), conjunction<Pn.
 
 namespace detail {
 
-FMT_CONSTEXPR inline void abort_fuzzing_if(bool condition) {
+EFP_FMT_CONSTEXPR inline void abort_fuzzing_if(bool condition) {
     ignore_unused(condition);
-#ifdef FMT_FUZZ
+#ifdef EFP_FMT_FUZZ
     if (condition)
         throw std::runtime_error("fuzzing limit reached");
 #endif
@@ -322,7 +322,7 @@ struct string_literal {
     }
 };
 
-#if FMT_CPLUSPLUS < 201703L
+#if EFP_FMT_CPLUSPLUS < 201703L
 template<typename CharT, CharT... C>
 constexpr CharT string_literal<CharT, C...>::value[sizeof...(C)];
 #endif
@@ -360,8 +360,8 @@ class formatbuf: public Streambuf {
 };
 
 // Implementation of std::bit_cast for pre-C++20.
-template<typename To, typename From, FMT_ENABLE_IF(sizeof(To) == sizeof(From))>
-FMT_CONSTEXPR20 auto bit_cast(const From& from) -> To {
+template<typename To, typename From, EFP_FMT_ENABLE_IF(sizeof(To) == sizeof(From))>
+EFP_FMT_CONSTEXPR20 auto bit_cast(const From& from) -> To {
 #ifdef __cpp_lib_bit_cast
     if (is_constant_evaluated())
         return std::bit_cast<To>(from);
@@ -405,7 +405,7 @@ class uint128_fallback {
         return lo_;
     }
 
-    template<typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
+    template<typename T, EFP_FMT_ENABLE_IF(std::is_integral<T>::value)>
     constexpr explicit operator T() const {
         return static_cast<T>(lo_);
     }
@@ -447,7 +447,7 @@ class uint128_fallback {
     }
 
     friend auto operator*(const uint128_fallback& lhs, uint32_t rhs) -> uint128_fallback {
-        FMT_ASSERT(lhs.hi_ == 0, "");
+        EFP_FMT_ASSERT(lhs.hi_ == 0, "");
         uint64_t hi = (lhs.lo_ >> 32) * rhs;
         uint64_t lo = (lhs.lo_ & ~uint32_t()) * rhs;
         uint64_t new_lo = (hi << 32) + lo;
@@ -458,7 +458,7 @@ class uint128_fallback {
         return {lhs.hi_ - (lhs.lo_ < rhs ? 1 : 0), lhs.lo_ - rhs};
     }
 
-    FMT_CONSTEXPR auto operator>>(int shift) const -> uint128_fallback {
+    EFP_FMT_CONSTEXPR auto operator>>(int shift) const -> uint128_fallback {
         if (shift == 64)
             return {0, hi_};
         if (shift > 64)
@@ -466,7 +466,7 @@ class uint128_fallback {
         return {hi_ >> shift, (hi_ << (64 - shift)) | (lo_ >> shift)};
     }
 
-    FMT_CONSTEXPR auto operator<<(int shift) const -> uint128_fallback {
+    EFP_FMT_CONSTEXPR auto operator<<(int shift) const -> uint128_fallback {
         if (shift == 64)
             return {lo_, 0};
         if (shift > 64)
@@ -474,34 +474,34 @@ class uint128_fallback {
         return {hi_ << shift | (lo_ >> (64 - shift)), (lo_ << shift)};
     }
 
-    FMT_CONSTEXPR auto operator>>=(int shift) -> uint128_fallback& {
+    EFP_FMT_CONSTEXPR auto operator>>=(int shift) -> uint128_fallback& {
         return *this = *this >> shift;
     }
 
-    FMT_CONSTEXPR void operator+=(uint128_fallback n) {
+    EFP_FMT_CONSTEXPR void operator+=(uint128_fallback n) {
         uint64_t new_lo = lo_ + n.lo_;
         uint64_t new_hi = hi_ + n.hi_ + (new_lo < lo_ ? 1 : 0);
-        FMT_ASSERT(new_hi >= hi_, "");
+        EFP_FMT_ASSERT(new_hi >= hi_, "");
         lo_ = new_lo;
         hi_ = new_hi;
     }
 
-    FMT_CONSTEXPR void operator&=(uint128_fallback n) {
+    EFP_FMT_CONSTEXPR void operator&=(uint128_fallback n) {
         lo_ &= n.lo_;
         hi_ &= n.hi_;
     }
 
-    FMT_CONSTEXPR20 uint128_fallback& operator+=(uint64_t n) noexcept {
+    EFP_FMT_CONSTEXPR20 uint128_fallback& operator+=(uint64_t n) noexcept {
         if (is_constant_evaluated()) {
             lo_ += n;
             hi_ += (lo_ < n ? 1 : 0);
             return *this;
         }
-#if FMT_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
+#if EFP_FMT_HAS_BUILTIN(__builtin_addcll) && !defined(__ibmxl__)
         unsigned long long carry;
         lo_ = __builtin_addcll(lo_, n, 0, &carry);
         hi_ += carry;
-#elif FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !defined(__ibmxl__)
+#elif EFP_FMT_HAS_BUILTIN(__builtin_ia32_addcarryx_u64) && !defined(__ibmxl__)
         unsigned long long result;
         auto carry = __builtin_ia32_addcarryx_u64(0, lo_, n, &result);
         lo_ = result;
@@ -517,7 +517,7 @@ class uint128_fallback {
     }
 };
 
-using uint128_t = efp::Conditional<FMT_USE_INT128, uint128_opt, uint128_fallback>;
+using uint128_t = efp::Conditional<EFP_FMT_USE_INT128, uint128_opt, uint128_fallback>;
 
 #ifdef UINTPTR_MAX
 using uintptr_t = ::uintptr_t;
@@ -550,7 +550,7 @@ constexpr auto num_bits<uint128_t>() -> int {
 
 // A heterogeneous bit_cast used for converting 96-bit long double to uint128_t
 // and 128-bit pointers to uint128_fallback.
-template<typename To, typename From, FMT_ENABLE_IF(sizeof(To) > sizeof(From))>
+template<typename To, typename From, EFP_FMT_ENABLE_IF(sizeof(To) > sizeof(From))>
 inline auto bit_cast(const From& from) -> To {
     constexpr auto size = static_cast<int>(sizeof(From) / sizeof(unsigned));
 
@@ -570,7 +570,7 @@ inline auto bit_cast(const From& from) -> To {
 }
 
 template<typename UInt>
-FMT_CONSTEXPR20 inline auto countl_zero_fallback(UInt n) -> int {
+EFP_FMT_CONSTEXPR20 inline auto countl_zero_fallback(UInt n) -> int {
     int lz = 0;
     constexpr UInt msb_mask = static_cast<UInt>(1) << (num_bits<UInt>() - 1);
     for (; (n & msb_mask) == 0; n <<= 1)
@@ -578,27 +578,27 @@ FMT_CONSTEXPR20 inline auto countl_zero_fallback(UInt n) -> int {
     return lz;
 }
 
-FMT_CONSTEXPR20 inline auto countl_zero(uint32_t n) -> int {
-#ifdef FMT_BUILTIN_CLZ
+EFP_FMT_CONSTEXPR20 inline auto countl_zero(uint32_t n) -> int {
+#ifdef EFP_FMT_BUILTIN_CLZ
     if (!is_constant_evaluated())
-        return FMT_BUILTIN_CLZ(n);
+        return EFP_FMT_BUILTIN_CLZ(n);
 #endif
     return countl_zero_fallback(n);
 }
 
-FMT_CONSTEXPR20 inline auto countl_zero(uint64_t n) -> int {
-#ifdef FMT_BUILTIN_CLZLL
+EFP_FMT_CONSTEXPR20 inline auto countl_zero(uint64_t n) -> int {
+#ifdef EFP_FMT_BUILTIN_CLZLL
     if (!is_constant_evaluated())
-        return FMT_BUILTIN_CLZLL(n);
+        return EFP_FMT_BUILTIN_CLZLL(n);
 #endif
     return countl_zero_fallback(n);
 }
 
-FMT_INLINE void assume(bool condition) {
+EFP_FMT_INLINE void assume(bool condition) {
     (void)condition;
-#if FMT_HAS_BUILTIN(__builtin_assume) && !FMT_ICC_VERSION
+#if EFP_FMT_HAS_BUILTIN(__builtin_assume) && !EFP_FMT_ICC_VERSION
     __builtin_assume(condition);
-#elif FMT_GCC_VERSION
+#elif EFP_FMT_GCC_VERSION
     if (!condition)
         __builtin_unreachable();
 #endif
@@ -623,8 +623,8 @@ inline auto get_data(Container& c) -> typename Container::value_type* {
 
 // Attempts to reserve space for n extra characters in the output range.
 // Returns a pointer to the reserved range or a reference to it.
-template<typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
-#if FMT_CLANG_VERSION >= 307 && !FMT_ICC_VERSION
+template<typename Container, EFP_FMT_ENABLE_IF(is_contiguous<Container>::value)>
+#if EFP_FMT_CLANG_VERSION >= 307 && !EFP_FMT_ICC_VERSION
 __attribute__((no_sanitize("undefined")))
 #endif
 inline auto
@@ -665,7 +665,7 @@ auto to_pointer(buffer_appender<T> it, size_t n) -> T* {
     return buf.data() + size;
 }
 
-template<typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
+template<typename Container, EFP_FMT_ENABLE_IF(is_contiguous<Container>::value)>
 inline auto base_iterator(std::back_insert_iterator<Container> it, typename Container::value_type*)
     -> std::back_insert_iterator<Container> {
     return it;
@@ -679,14 +679,14 @@ constexpr auto base_iterator(Iterator, Iterator it) -> Iterator {
 // <algorithm> is spectacularly slow to compile in C++20 so use a simple fill_n
 // instead (#1998).
 template<typename OutputIt, typename Size, typename T>
-FMT_CONSTEXPR auto fill_n(OutputIt out, Size count, const T& value) -> OutputIt {
+EFP_FMT_CONSTEXPR auto fill_n(OutputIt out, Size count, const T& value) -> OutputIt {
     for (Size i = 0; i < count; ++i)
         *out++ = value;
     return out;
 }
 
 template<typename T, typename Size>
-FMT_CONSTEXPR20 auto fill_n(T* out, Size count, char value) -> T* {
+EFP_FMT_CONSTEXPR20 auto fill_n(T* out, Size count, char value) -> T* {
     if (is_constant_evaluated()) {
         return fill_n<T*, Size, T>(out, count, value);
     }
@@ -708,7 +708,7 @@ using char8_type = char;
 #endif
 
 template<typename OutChar, typename InputIt, typename OutputIt>
-FMT_CONSTEXPR FMT_NOINLINE auto copy_str_noinline(InputIt begin, InputIt end, OutputIt out)
+EFP_FMT_CONSTEXPR EFP_FMT_NOINLINE auto copy_str_noinline(InputIt begin, InputIt end, OutputIt out)
     -> OutputIt {
     return copy_str<OutChar>(begin, end, out);
 }
@@ -730,7 +730,7 @@ FMT_CONSTEXPR FMT_NOINLINE auto copy_str_noinline(InputIt begin, InputIt end, Ou
  * occurs, this pointer will be a guess that depends on the particular
  * error, but it will always advance at least one byte.
  */
-FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e) -> const char* {
+EFP_FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e) -> const char* {
     constexpr const int masks[] = {0x00, 0x7f, 0x1f, 0x0f, 0x07};
     constexpr const uint32_t mins[] = {4194304, 0, 128, 2048, 65536};
     constexpr const int shiftc[] = {0, 18, 12, 6, 0};
@@ -766,12 +766,12 @@ FMT_CONSTEXPR inline auto utf8_decode(const char* s, uint32_t* c, int* e) -> con
     return next;
 }
 
-constexpr FMT_INLINE_VARIABLE uint32_t invalid_code_point = ~uint32_t();
+constexpr EFP_FMT_INLINE_VARIABLE uint32_t invalid_code_point = ~uint32_t();
 
 // Invokes f(cp, sv) for every code point cp in s with sv being the string view
 // corresponding to the code point. cp is invalid_code_point on error.
 template<typename F>
-FMT_CONSTEXPR void for_each_codepoint(string_view s, F f) {
+EFP_FMT_CONSTEXPR void for_each_codepoint(string_view s, F f) {
     auto decode = [f](const char* buf_ptr, const char* ptr) {
         auto cp = uint32_t();
         auto error = 0;
@@ -810,14 +810,14 @@ inline auto compute_width(basic_string_view<Char> s) -> size_t {
 }
 
 // Computes approximate display width of a UTF-8 string.
-FMT_CONSTEXPR inline size_t compute_width(string_view s) {
+EFP_FMT_CONSTEXPR inline size_t compute_width(string_view s) {
     size_t num_code_points = 0;
 
     // It is not a lambda for compatibility with C++14.
     struct count_code_points {
         size_t* count;
 
-        FMT_CONSTEXPR auto operator()(uint32_t cp, string_view) const -> bool {
+        EFP_FMT_CONSTEXPR auto operator()(uint32_t cp, string_view) const -> bool {
             *count += detail::to_unsigned(
                 1
                 + (cp >= 0x1100
@@ -899,34 +899,34 @@ using is_integer = efp::Bool<
     is_integral<T>::value && !efp::IsSame<T, bool>::value && !efp::IsSame<T, char>::value
     && !efp::IsSame<T, wchar_t>::value>;
 
-#ifndef FMT_USE_FLOAT
-    #define FMT_USE_FLOAT 1
+#ifndef EFP_FMT_USE_FLOAT
+    #define EFP_FMT_USE_FLOAT 1
 #endif
-#ifndef FMT_USE_DOUBLE
-    #define FMT_USE_DOUBLE 1
+#ifndef EFP_FMT_USE_DOUBLE
+    #define EFP_FMT_USE_DOUBLE 1
 #endif
-#ifndef FMT_USE_LONG_DOUBLE
-    #define FMT_USE_LONG_DOUBLE 1
+#ifndef EFP_FMT_USE_LONG_DOUBLE
+    #define EFP_FMT_USE_LONG_DOUBLE 1
 #endif
 
-#ifndef FMT_USE_FLOAT128
+#ifndef EFP_FMT_USE_FLOAT128
     #ifdef __clang__
         // Clang emulates GCC, so it has to appear early.
-        #if FMT_HAS_INCLUDE(<quadmath.h>)
-            #define FMT_USE_FLOAT128 1
+        #if EFP_FMT_HAS_INCLUDE(<quadmath.h>)
+            #define EFP_FMT_USE_FLOAT128 1
         #endif
     #elif defined(__GNUC__)
         // GNU C++:
         #if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__)
-            #define FMT_USE_FLOAT128 1
+            #define EFP_FMT_USE_FLOAT128 1
         #endif
     #endif
-    #ifndef FMT_USE_FLOAT128
-        #define FMT_USE_FLOAT128 0
+    #ifndef EFP_FMT_USE_FLOAT128
+        #define EFP_FMT_USE_FLOAT128 0
     #endif
 #endif
 
-#if FMT_USE_FLOAT128
+#if EFP_FMT_USE_FLOAT128
 using float128 = __float128;
 #else
 using float128 = void;
@@ -946,8 +946,8 @@ struct is_fast_float<T, false>: efp::False {};
 template<typename T>
 using is_double_double = efp::Bool<efp::NumericLimits<T>::digits == 106>;
 
-#ifndef FMT_USE_FULL_CACHE_DRAGONBOX
-    #define FMT_USE_FULL_CACHE_DRAGONBOX 0
+#ifndef EFP_FMT_USE_FULL_CACHE_DRAGONBOX
+    #define EFP_FMT_USE_FULL_CACHE_DRAGONBOX 0
 #endif
 
 template<typename T>
@@ -972,7 +972,7 @@ template<typename T>
 struct is_locale<T, void_t<decltype(T::classic())>>: efp::True {};
 }  // namespace detail
 
-FMT_BEGIN_EXPORT
+EFP_FMT_BEGIN_EXPORT
 
 // The number of characters to store in the basic_memory_buffer object itself
 // to avoid dynamic memory allocation.
@@ -1005,17 +1005,17 @@ class basic_memory_buffer final: public detail::buffer<T> {
     T store_[SIZE];
 
     // Don't inherit from Allocator to avoid generating type_info for it.
-    FMT_NO_UNIQUE_ADDRESS Allocator alloc_;
+    EFP_FMT_NO_UNIQUE_ADDRESS Allocator alloc_;
 
     // Deallocate memory allocated by the buffer.
-    FMT_CONSTEXPR20 void deallocate() {
+    EFP_FMT_CONSTEXPR20 void deallocate() {
         T* data = this->data();
         if (data != store_)
             alloc_.deallocate(data, this->capacity());
     }
 
   protected:
-    FMT_CONSTEXPR20 void grow(size_t size) override {
+    EFP_FMT_CONSTEXPR20 void grow(size_t size) override {
         detail::abort_fuzzing_if(size > 5000);
         const size_t max_size = std::allocator_traits<Allocator>::max_size(alloc_);
         size_t old_capacity = this->capacity();
@@ -1042,20 +1042,20 @@ class basic_memory_buffer final: public detail::buffer<T> {
     using value_type = T;
     using const_reference = const T&;
 
-    FMT_CONSTEXPR20 explicit basic_memory_buffer(const Allocator& alloc = Allocator())
+    EFP_FMT_CONSTEXPR20 explicit basic_memory_buffer(const Allocator& alloc = Allocator())
         : alloc_(alloc) {
         this->set(store_, SIZE);
         if (detail::is_constant_evaluated())
             detail::fill_n(store_, SIZE, T());
     }
 
-    FMT_CONSTEXPR20 ~basic_memory_buffer() {
+    EFP_FMT_CONSTEXPR20 ~basic_memory_buffer() {
         deallocate();
     }
 
   private:
     // Move data from other to this buffer.
-    FMT_CONSTEXPR20 void move(basic_memory_buffer& other) {
+    EFP_FMT_CONSTEXPR20 void move(basic_memory_buffer& other) {
         alloc_ = efp::move(other.alloc_);
         T* data = other.data();
         size_t size = other.size(), capacity = other.capacity();
@@ -1079,7 +1079,7 @@ class basic_memory_buffer final: public detail::buffer<T> {
     of the other object to it.
     \endrst
    */
-    FMT_CONSTEXPR20 basic_memory_buffer(basic_memory_buffer&& other) noexcept {
+    EFP_FMT_CONSTEXPR20 basic_memory_buffer(basic_memory_buffer&& other) noexcept {
         move(other);
     }
 
@@ -1089,7 +1089,7 @@ class basic_memory_buffer final: public detail::buffer<T> {
     \endrst
    */
     auto operator=(basic_memory_buffer&& other) noexcept -> basic_memory_buffer& {
-        FMT_ASSERT(this != &other, "");
+        EFP_FMT_ASSERT(this != &other, "");
         deallocate();
         move(other);
         return *this;
@@ -1104,7 +1104,7 @@ class basic_memory_buffer final: public detail::buffer<T> {
     Resizes the buffer to contain *count* elements. If T is a POD type new
     elements may not be initialized.
    */
-    FMT_CONSTEXPR20 void resize(size_t count) {
+    EFP_FMT_CONSTEXPR20 void resize(size_t count) {
         this->try_resize(count);
     }
 
@@ -1127,28 +1127,28 @@ using memory_buffer = basic_memory_buffer<char>;
 template<typename T, size_t SIZE, typename Allocator>
 struct is_contiguous<basic_memory_buffer<T, SIZE, Allocator>>: efp::True {};
 
-FMT_END_EXPORT
+EFP_FMT_END_EXPORT
 
 namespace detail {
-FMT_API bool write_console(int fd, string_view text);
-FMT_API void print(std::FILE*, string_view);
+EFP_FMT_API bool write_console(int fd, string_view text);
+EFP_FMT_API void print(std::FILE*, string_view);
 }  // namespace detail
 
-FMT_BEGIN_EXPORT
+EFP_FMT_BEGIN_EXPORT
 
 // Suppress a misleading warning in older versions of clang.
-#if FMT_CLANG_VERSION
+#if EFP_FMT_CLANG_VERSION
     #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
 
 /** An error reported from a formatting function. */
-class FMT_SO_VISIBILITY("default") format_error: public std::runtime_error {
+class EFP_FMT_SO_VISIBILITY("default") format_error: public std::runtime_error {
   public:
     using std::runtime_error::runtime_error;
 };
 
 namespace detail_exported {
-#if FMT_USE_NONTYPE_TEMPLATE_ARGS
+#if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
 template<typename Char, size_t N>
 struct fixed_string {
     constexpr fixed_string(const Char (&str)[N]) {
@@ -1178,10 +1178,10 @@ class loc_value {
     basic_format_arg<format_context> value_;
 
   public:
-    template<typename T, FMT_ENABLE_IF(!detail::is_float128<T>::value)>
+    template<typename T, EFP_FMT_ENABLE_IF(!detail::is_float128<T>::value)>
     loc_value(T value) : value_(detail::make_arg<format_context>(value)) {}
 
-    template<typename T, FMT_ENABLE_IF(detail::is_float128<T>::value)>
+    template<typename T, EFP_FMT_ENABLE_IF(detail::is_float128<T>::value)>
     loc_value(T) {}
 
     template<typename Visitor>
@@ -1203,7 +1203,7 @@ class format_facet: public Locale::facet {
     virtual auto do_put(appender out, loc_value val, const format_specs<>& specs) const -> bool;
 
   public:
-    static FMT_API typename Locale::id id;
+    static EFP_FMT_API typename Locale::id id;
 
     explicit format_facet(Locale& loc);
 
@@ -1224,24 +1224,24 @@ namespace detail {
 
 // Returns true if value is negative, false otherwise.
 // Same as `value < 0` but doesn't produce warnings if T is an unsigned type.
-template<typename T, FMT_ENABLE_IF(is_signed<T>::value)>
+template<typename T, EFP_FMT_ENABLE_IF(is_signed<T>::value)>
 constexpr auto is_negative(T value) -> bool {
     return value < 0;
 }
 
-template<typename T, FMT_ENABLE_IF(!is_signed<T>::value)>
+template<typename T, EFP_FMT_ENABLE_IF(!is_signed<T>::value)>
 constexpr auto is_negative(T) -> bool {
     return false;
 }
 
 template<typename T>
-FMT_CONSTEXPR auto is_supported_floating_point(T) -> bool {
+EFP_FMT_CONSTEXPR auto is_supported_floating_point(T) -> bool {
     if (efp::IsSame<T, float>())
-        return FMT_USE_FLOAT;
+        return EFP_FMT_USE_FLOAT;
     if (efp::IsSame<T, double>())
-        return FMT_USE_DOUBLE;
+        return EFP_FMT_USE_DOUBLE;
     if (efp::IsSame<T, long double>())
-        return FMT_USE_LONG_DOUBLE;
+        return EFP_FMT_USE_LONG_DOUBLE;
     return true;
 }
 
@@ -1249,13 +1249,13 @@ FMT_CONSTEXPR auto is_supported_floating_point(T) -> bool {
 // represent all values of an integral type T.
 template<typename T>
 using uint32_or_64_or_128_t = efp::Conditional<
-    num_bits<T>() <= 32 && !FMT_REDUCE_INT_INSTANTIATIONS,
+    num_bits<T>() <= 32 && !EFP_FMT_REDUCE_INT_INSTANTIATIONS,
     uint32_t,
     efp::Conditional<num_bits<T>() <= 64, uint64_t, uint128_t>>;
 template<typename T>
 using uint64_or_128_t = efp::Conditional<num_bits<T>() <= 64, uint64_t, uint128_t>;
 
-#define FMT_POWERS_OF_10(factor) \
+#define EFP_FMT_POWERS_OF_10(factor) \
     factor * 10, (factor) * 100, (factor) * 1000, (factor) * 10000, (factor) * 100000, \
         (factor) * 1000000, (factor) * 10000000, (factor) * 100000000, (factor) * 1000000000
 
@@ -1272,14 +1272,14 @@ constexpr const char* digits2(size_t value) {
 // Sign is a template parameter to workaround a bug in gcc 4.8.
 template<typename Char, typename Sign>
 constexpr Char sign(Sign s) {
-#if !FMT_GCC_VERSION || FMT_GCC_VERSION >= 604
+#if !EFP_FMT_GCC_VERSION || EFP_FMT_GCC_VERSION >= 604
     static_assert(efp::IsSame<Sign, sign_t>::value, "");
 #endif
     return static_cast<Char>("\0-+ "[s]);
 }
 
 template<typename T>
-FMT_CONSTEXPR auto count_digits_fallback(T n) -> int {
+EFP_FMT_CONSTEXPR auto count_digits_fallback(T n) -> int {
     int count = 1;
     for (;;) {
         // Integer division is slow so do it for a group of four digits instead
@@ -1297,13 +1297,13 @@ FMT_CONSTEXPR auto count_digits_fallback(T n) -> int {
         count += 4;
     }
 }
-#if FMT_USE_INT128
-FMT_CONSTEXPR inline auto count_digits(uint128_opt n) -> int {
+#if EFP_FMT_USE_INT128
+EFP_FMT_CONSTEXPR inline auto count_digits(uint128_opt n) -> int {
     return count_digits_fallback(n);
 }
 #endif
 
-#ifdef FMT_BUILTIN_CLZLL
+#ifdef EFP_FMT_BUILTIN_CLZLL
 // It is a separate function rather than a part of count_digits to workaround
 // the lack of static constexpr in constexpr functions.
 inline auto do_count_digits(uint64_t n) -> int {
@@ -1316,17 +1316,17 @@ inline auto do_count_digits(uint64_t n) -> int {
                                             9,  9,  9,  10, 10, 10, 10, 11, 11, 11, 12, 12, 12,
                                             13, 13, 13, 13, 14, 14, 14, 15, 15, 15, 16, 16, 16,
                                             16, 17, 17, 17, 18, 18, 18, 19, 19, 19, 19, 20};
-    auto t = bsr2log10[FMT_BUILTIN_CLZLL(n | 1) ^ 63];
+    auto t = bsr2log10[EFP_FMT_BUILTIN_CLZLL(n | 1) ^ 63];
     static constexpr const uint64_t zero_or_powers_of_10[] =
-        {0, 0, FMT_POWERS_OF_10(1U), FMT_POWERS_OF_10(1000000000ULL), 10000000000000000000ULL};
+        {0, 0, EFP_FMT_POWERS_OF_10(1U), EFP_FMT_POWERS_OF_10(1000000000ULL), 10000000000000000000ULL};
     return t - (n < zero_or_powers_of_10[t]);
 }
 #endif
 
 // Returns the number of decimal digits in n. Leading zeros are not counted
 // except for n == 0 in which case count_digits returns 1.
-FMT_CONSTEXPR20 inline auto count_digits(uint64_t n) -> int {
-#ifdef FMT_BUILTIN_CLZLL
+EFP_FMT_CONSTEXPR20 inline auto count_digits(uint64_t n) -> int {
+#ifdef EFP_FMT_BUILTIN_CLZLL
     if (!is_constant_evaluated()) {
         return do_count_digits(n);
     }
@@ -1336,10 +1336,10 @@ FMT_CONSTEXPR20 inline auto count_digits(uint64_t n) -> int {
 
 // Counts the number of digits in n. BITS = log2(radix).
 template<int BITS, typename UInt>
-FMT_CONSTEXPR auto count_digits(UInt n) -> int {
-#ifdef FMT_BUILTIN_CLZ
+EFP_FMT_CONSTEXPR auto count_digits(UInt n) -> int {
+#ifdef EFP_FMT_BUILTIN_CLZ
     if (!is_constant_evaluated() && num_bits<UInt>() == 32)
-        return (FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
+        return (EFP_FMT_BUILTIN_CLZ(static_cast<uint32_t>(n) | 1) ^ 31) / BITS + 1;
 #endif
     // Lambda avoids unreachable code warnings from NVHPC.
     return [](UInt m) {
@@ -1351,34 +1351,34 @@ FMT_CONSTEXPR auto count_digits(UInt n) -> int {
     }(n);
 }
 
-#ifdef FMT_BUILTIN_CLZ
+#ifdef EFP_FMT_BUILTIN_CLZ
 // It is a separate function rather than a part of count_digits to workaround
 // the lack of static constexpr in constexpr functions.
-FMT_INLINE auto do_count_digits(uint32_t n) -> int {
+EFP_FMT_INLINE auto do_count_digits(uint32_t n) -> int {
     // An optimization by Kendall Willets from https://bit.ly/3uOIQrB.
     // This increments the upper 32 bits (log10(T) - 1) when >= T is added.
-    #define FMT_INC(T) (((sizeof(#T) - 1ull) << 32) - T)
+    #define EFP_FMT_INC(T) (((sizeof(#T) - 1ull) << 32) - T)
     static constexpr uint64_t table[] = {
-        FMT_INC(0),          FMT_INC(0),          FMT_INC(0),           // 8
-        FMT_INC(10),         FMT_INC(10),         FMT_INC(10),          // 64
-        FMT_INC(100),        FMT_INC(100),        FMT_INC(100),         // 512
-        FMT_INC(1000),       FMT_INC(1000),       FMT_INC(1000),        // 4096
-        FMT_INC(10000),      FMT_INC(10000),      FMT_INC(10000),       // 32k
-        FMT_INC(100000),     FMT_INC(100000),     FMT_INC(100000),      // 256k
-        FMT_INC(1000000),    FMT_INC(1000000),    FMT_INC(1000000),     // 2048k
-        FMT_INC(10000000),   FMT_INC(10000000),   FMT_INC(10000000),    // 16M
-        FMT_INC(100000000),  FMT_INC(100000000),  FMT_INC(100000000),   // 128M
-        FMT_INC(1000000000), FMT_INC(1000000000), FMT_INC(1000000000),  // 1024M
-        FMT_INC(1000000000), FMT_INC(1000000000)                        // 4B
+        EFP_FMT_INC(0),          EFP_FMT_INC(0),          EFP_FMT_INC(0),           // 8
+        EFP_FMT_INC(10),         EFP_FMT_INC(10),         EFP_FMT_INC(10),          // 64
+        EFP_FMT_INC(100),        EFP_FMT_INC(100),        EFP_FMT_INC(100),         // 512
+        EFP_FMT_INC(1000),       EFP_FMT_INC(1000),       EFP_FMT_INC(1000),        // 4096
+        EFP_FMT_INC(10000),      EFP_FMT_INC(10000),      EFP_FMT_INC(10000),       // 32k
+        EFP_FMT_INC(100000),     EFP_FMT_INC(100000),     EFP_FMT_INC(100000),      // 256k
+        EFP_FMT_INC(1000000),    EFP_FMT_INC(1000000),    EFP_FMT_INC(1000000),     // 2048k
+        EFP_FMT_INC(10000000),   EFP_FMT_INC(10000000),   EFP_FMT_INC(10000000),    // 16M
+        EFP_FMT_INC(100000000),  EFP_FMT_INC(100000000),  EFP_FMT_INC(100000000),   // 128M
+        EFP_FMT_INC(1000000000), EFP_FMT_INC(1000000000), EFP_FMT_INC(1000000000),  // 1024M
+        EFP_FMT_INC(1000000000), EFP_FMT_INC(1000000000)                        // 4B
     };
-    auto inc = table[FMT_BUILTIN_CLZ(n | 1) ^ 31];
+    auto inc = table[EFP_FMT_BUILTIN_CLZ(n | 1) ^ 31];
     return static_cast<int>((n + inc) >> 32);
 }
 #endif
 
 // Optional version of count_digits for better performance on 32-bit platforms.
-FMT_CONSTEXPR20 inline auto count_digits(uint32_t n) -> int {
-#ifdef FMT_BUILTIN_CLZ
+EFP_FMT_CONSTEXPR20 inline auto count_digits(uint32_t n) -> int {
+#ifdef EFP_FMT_BUILTIN_CLZ
     if (!is_constant_evaluated()) {
         return do_count_digits(n);
     }
@@ -1408,7 +1408,7 @@ struct thousands_sep_result {
 };
 
 template<typename Char>
-FMT_API auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char>;
+EFP_FMT_API auto thousands_sep_impl(locale_ref loc) -> thousands_sep_result<Char>;
 
 template<typename Char>
 inline auto thousands_sep(locale_ref loc) -> thousands_sep_result<Char> {
@@ -1422,7 +1422,7 @@ inline auto thousands_sep(locale_ref loc) -> thousands_sep_result<wchar_t> {
 }
 
 template<typename Char>
-FMT_API auto decimal_point_impl(locale_ref loc) -> Char;
+EFP_FMT_API auto decimal_point_impl(locale_ref loc) -> Char;
 
 template<typename Char>
 inline auto decimal_point(locale_ref loc) -> Char {
@@ -1446,7 +1446,7 @@ inline auto equal2(const char* lhs, const char* rhs) -> bool {
 
 // Copies two characters from src to dst.
 template<typename Char>
-FMT_CONSTEXPR20 FMT_INLINE void copy2(Char* dst, const char* src) {
+EFP_FMT_CONSTEXPR20 EFP_FMT_INLINE void copy2(Char* dst, const char* src) {
     if (!is_constant_evaluated() && sizeof(Char) == sizeof(char)) {
         memcpy(dst, src, 2);
         return;
@@ -1465,9 +1465,9 @@ struct format_decimal_result {
 // buffer of specified size. The caller must ensure that the buffer is large
 // enough.
 template<typename Char, typename UInt>
-FMT_CONSTEXPR20 auto format_decimal(Char* out, UInt value, int size)
+EFP_FMT_CONSTEXPR20 auto format_decimal(Char* out, UInt value, int size)
     -> format_decimal_result<Char*> {
-    FMT_ASSERT(size >= count_digits(value), "invalid digit count");
+    EFP_FMT_ASSERT(size >= count_digits(value), "invalid digit count");
     out += size;
     Char* end = out;
     while (value >= 100) {
@@ -1491,8 +1491,8 @@ template<
     typename Char,
     typename UInt,
     typename Iterator,
-    FMT_ENABLE_IF(!std::is_pointer<efp::CVRefRemoved<Iterator>>::value)>
-FMT_CONSTEXPR inline auto format_decimal(Iterator out, UInt value, int size)
+    EFP_FMT_ENABLE_IF(!std::is_pointer<efp::CVRefRemoved<Iterator>>::value)>
+EFP_FMT_CONSTEXPR inline auto format_decimal(Iterator out, UInt value, int size)
     -> format_decimal_result<Iterator> {
     // Buffer is large enough to hold all digits (digits10 + 1).
     Char buffer[digits10<UInt>() + 1] = {};
@@ -1501,7 +1501,7 @@ FMT_CONSTEXPR inline auto format_decimal(Iterator out, UInt value, int size)
 }
 
 template<unsigned BASE_BITS, typename Char, typename UInt>
-FMT_CONSTEXPR auto format_uint(Char* buffer, UInt value, int num_digits, bool upper = false)
+EFP_FMT_CONSTEXPR auto format_uint(Char* buffer, UInt value, int num_digits, bool upper = false)
     -> Char* {
     buffer += num_digits;
     Char* end = buffer;
@@ -1515,7 +1515,7 @@ FMT_CONSTEXPR auto format_uint(Char* buffer, UInt value, int num_digits, bool up
 }
 
 template<unsigned BASE_BITS, typename Char, typename It, typename UInt>
-FMT_CONSTEXPR inline auto format_uint(It out, UInt value, int num_digits, bool upper = false)
+EFP_FMT_CONSTEXPR inline auto format_uint(It out, UInt value, int num_digits, bool upper = false)
     -> It {
     if (auto ptr = to_pointer<Char>(out, to_unsigned(num_digits))) {
         format_uint<BASE_BITS>(ptr, value, num_digits, upper);
@@ -1533,7 +1533,7 @@ class utf8_to_utf16 {
     basic_memory_buffer<wchar_t> buffer_;
 
   public:
-    FMT_API explicit utf8_to_utf16(string_view s);
+    EFP_FMT_API explicit utf8_to_utf16(string_view s);
 
     operator basic_string_view<wchar_t>() const {
         return {&buffer_[0], size()};
@@ -1569,7 +1569,7 @@ class to_utf8 {
     ) {
         static_assert(sizeof(WChar) == 2 || sizeof(WChar) == 4, "Expect utf16 or utf32");
         if (!convert(s, policy))
-            FMT_THROW(std::runtime_error(sizeof(WChar) == 2 ? "invalid utf16" : "invalid utf32"));
+            EFP_FMT_THROW(std::runtime_error(sizeof(WChar) == 2 ? "invalid utf16" : "invalid utf32"));
     }
 
     operator string_view() const {
@@ -1641,7 +1641,7 @@ class to_utf8 {
 
 // Computes 128-bit result of multiplication of two 64-bit unsigned integers.
 inline uint128_fallback umul128(uint64_t x, uint64_t y) noexcept {
-#if FMT_USE_INT128
+#if EFP_FMT_USE_INT128
     auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
     return {static_cast<uint64_t>(p >> 64), static_cast<uint64_t>(p)};
 #elif defined(_MSC_VER) && defined(_M_X64)
@@ -1674,19 +1674,19 @@ namespace dragonbox {
     // Computes floor(log10(pow(2, e))) for e in [-2620, 2620] using the method from
     // https://fmt.dev/papers/Dragonbox.pdf#page=28, section 6.1.
     inline int floor_log10_pow2(int e) noexcept {
-        FMT_ASSERT(e <= 2620 && e >= -2620, "too large exponent");
+        EFP_FMT_ASSERT(e <= 2620 && e >= -2620, "too large exponent");
         static_assert((-1 >> 1) == -1, "right shift is not arithmetic");
         return (e * 315653) >> 20;
     }
 
     inline int floor_log2_pow10(int e) noexcept {
-        FMT_ASSERT(e <= 1233 && e >= -1233, "too large exponent");
+        EFP_FMT_ASSERT(e <= 1233 && e >= -1233, "too large exponent");
         return (e * 1741647) >> 19;
     }
 
     // Computes upper 64 bits of multiplication of two 64-bit unsigned integers.
     inline uint64_t umul128_upper64(uint64_t x, uint64_t y) noexcept {
-#if FMT_USE_INT128
+#if EFP_FMT_USE_INT128
         auto p = static_cast<uint128_opt>(x) * static_cast<uint128_opt>(y);
         return static_cast<uint64_t>(p >> 64);
 #elif defined(_MSC_VER) && defined(_M_X64)
@@ -1704,7 +1704,7 @@ namespace dragonbox {
         return r;
     }
 
-    FMT_API uint128_fallback get_cached_power(int k) noexcept;
+    EFP_FMT_API uint128_fallback get_cached_power(int k) noexcept;
 
     // Type-specific information that Dragonbox uses.
     template<typename T, typename Enable = void>
@@ -1761,7 +1761,7 @@ namespace dragonbox {
     };
 
     template<typename T>
-    FMT_API auto to_decimal(T x) noexcept -> decimal_fp<T>;
+    EFP_FMT_API auto to_decimal(T x) noexcept -> decimal_fp<T>;
 }  // namespace dragonbox
 
 // Returns true iff Float has the implicit bit which is not stored.
@@ -1796,8 +1796,8 @@ constexpr auto exponent_bias() -> int {
 
 // Writes the exponent exp in the form "[+-]d{2,3}" to buffer.
 template<typename Char, typename It>
-FMT_CONSTEXPR auto write_exponent(int exp, It it) -> It {
-    FMT_ASSERT(-10000 < exp && exp < 10000, "exponent out of range");
+EFP_FMT_CONSTEXPR auto write_exponent(int exp, It it) -> It {
+    EFP_FMT_ASSERT(-10000 < exp && exp < 10000, "exponent out of range");
     if (exp < 0) {
         *it++ = static_cast<Char>('-');
         exp = -exp;
@@ -1832,13 +1832,13 @@ struct basic_fp {
 
     // Constructs fp from an IEEE754 floating-point number.
     template<typename Float>
-    FMT_CONSTEXPR basic_fp(Float n) {
+    EFP_FMT_CONSTEXPR basic_fp(Float n) {
         assign(n);
     }
 
     // Assigns n to this and return true iff predecessor is closer than successor.
-    template<typename Float, FMT_ENABLE_IF(!is_double_double<Float>::value)>
-    FMT_CONSTEXPR auto assign(Float n) -> bool {
+    template<typename Float, EFP_FMT_ENABLE_IF(!is_double_double<Float>::value)>
+    EFP_FMT_CONSTEXPR auto assign(Float n) -> bool {
         static_assert(efp::NumericLimits<Float>::digits <= 113, "unsupported FP");
         // Assume Float is in the format [sign][exponent][significand].
         using carrier_uint = typename dragonbox::float_info<Float>::carrier_uint;
@@ -1862,8 +1862,8 @@ struct basic_fp {
         return is_predecessor_closer;
     }
 
-    template<typename Float, FMT_ENABLE_IF(is_double_double<Float>::value)>
-    FMT_CONSTEXPR auto assign(Float n) -> bool {
+    template<typename Float, EFP_FMT_ENABLE_IF(is_double_double<Float>::value)>
+    EFP_FMT_CONSTEXPR auto assign(Float n) -> bool {
         static_assert(efp::NumericLimits<double>::is_iec559, "unsupported FP");
         return assign(static_cast<double>(n));
     }
@@ -1873,7 +1873,7 @@ using fp = basic_fp<unsigned long long>;
 
 // Normalizes the value converted from double and multiplied by (1 << SHIFT).
 template<int SHIFT = 0, typename F>
-FMT_CONSTEXPR basic_fp<F> normalize(basic_fp<F> value) {
+EFP_FMT_CONSTEXPR basic_fp<F> normalize(basic_fp<F> value) {
     // Handle subnormals.
     const auto implicit_bit = F(1) << num_significand_bits<double>();
     const auto shifted_implicit_bit = implicit_bit << SHIFT;
@@ -1890,8 +1890,8 @@ FMT_CONSTEXPR basic_fp<F> normalize(basic_fp<F> value) {
 }
 
 // Computes lhs * rhs / pow(2, 64) rounded to nearest with half-up tie breaking.
-FMT_CONSTEXPR inline uint64_t multiply(uint64_t lhs, uint64_t rhs) {
-#if FMT_USE_INT128
+EFP_FMT_CONSTEXPR inline uint64_t multiply(uint64_t lhs, uint64_t rhs) {
+#if EFP_FMT_USE_INT128
     auto product = static_cast<__uint128_t>(lhs) * rhs;
     auto f = static_cast<uint64_t>(product >> 64);
     return (static_cast<uint64_t>(product) & (1ULL << 63)) != 0 ? f + 1 : f;
@@ -1907,7 +1907,7 @@ FMT_CONSTEXPR inline uint64_t multiply(uint64_t lhs, uint64_t rhs) {
 #endif
 }
 
-FMT_CONSTEXPR inline fp operator*(fp x, fp y) {
+EFP_FMT_CONSTEXPR inline fp operator*(fp x, fp y) {
     return {multiply(x.f, y.f), x.e + y.e + 64};
 }
 
@@ -1920,7 +1920,7 @@ constexpr auto convert_float(T value) -> convert_float_result<T> {
 }
 
 template<typename OutputIt, typename Char>
-FMT_NOINLINE FMT_CONSTEXPR auto fill(OutputIt it, size_t n, const fill_t<Char>& fill) -> OutputIt {
+EFP_FMT_NOINLINE EFP_FMT_CONSTEXPR auto fill(OutputIt it, size_t n, const fill_t<Char>& fill) -> OutputIt {
     auto fill_size = fill.size();
     if (fill_size == 1)
         return detail::fill_n(it, n, fill[0]);
@@ -1934,7 +1934,7 @@ FMT_NOINLINE FMT_CONSTEXPR auto fill(OutputIt it, size_t n, const fill_t<Char>& 
 // size: output size in code units.
 // width: output display width in (terminal) column positions.
 template<align::type align = align::left, typename OutputIt, typename Char, typename F>
-FMT_CONSTEXPR auto
+EFP_FMT_CONSTEXPR auto
 write_padded(OutputIt out, const format_specs<Char>& specs, size_t size, size_t width, F&& f)
     -> OutputIt {
     static_assert(align == align::left || align == align::right, "");
@@ -1961,7 +1961,7 @@ constexpr auto write_padded(OutputIt out, const format_specs<Char>& specs, size_
 }
 
 template<align::type align = align::left, typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write_bytes(OutputIt out, string_view bytes, const format_specs<Char>& specs)
+EFP_FMT_CONSTEXPR auto write_bytes(OutputIt out, string_view bytes, const format_specs<Char>& specs)
     -> OutputIt {
     return write_padded<align>(out, specs, bytes.size(), [bytes](reserve_iterator<OutputIt> it) {
         const char* data = bytes.data();
@@ -1983,7 +1983,7 @@ auto write_ptr(OutputIt out, UIntPtr value, const format_specs<Char>* specs) -> 
 }
 
 // Returns true iff the code point cp is printable.
-FMT_API auto is_printable(uint32_t cp) -> bool;
+EFP_FMT_API auto is_printable(uint32_t cp) -> bool;
 
 inline auto needs_escape(uint32_t cp) -> bool {
     return cp < 0x20 || cp == 0x7f || cp == '"' || cp == '\\' || !is_printable(cp);
@@ -2031,18 +2031,18 @@ inline auto find_escape(const char* begin, const char* end) -> find_escape_resul
     return result;
 }
 
-#define FMT_STRING_IMPL(s, base, explicit) \
+#define EFP_FMT_STRING_IMPL(s, base, explicit) \
     [] { \
         /* Use the hidden visibility as a workaround for a GCC bug (#1973). */ \
         /* Use a macro-like name to avoid shadowing warnings. */ \
-        struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING: base { \
-            using char_type FMT_MAYBE_UNUSED = efp::CVRefRemoved<decltype(s[0])>; \
-            FMT_MAYBE_UNUSED FMT_CONSTEXPR explicit \
+        struct EFP_FMT_VISIBILITY("hidden") EFP_FMT_COMPILE_STRING: base { \
+            using char_type EFP_FMT_MAYBE_UNUSED = efp::CVRefRemoved<decltype(s[0])>; \
+            EFP_FMT_MAYBE_UNUSED EFP_FMT_CONSTEXPR explicit \
             operator efp_fmt::basic_string_view<char_type>() const { \
                 return efp_fmt::detail_exported::compile_string_to_view<char_type>(s); \
             } \
         }; \
-        return FMT_COMPILE_STRING(); \
+        return EFP_FMT_COMPILE_STRING(); \
     }()
 
 /**
@@ -2052,10 +2052,10 @@ inline auto find_escape(const char* begin, const char* end) -> find_escape_resul
   **Example**::
 
     // A compile-time error because 'd' is an invalid specifier for strings.
-    efp::String s = efp_fmt::format(FMT_STRING("{:d}"), "foo");
+    efp::String s = efp_fmt::format(EFP_FMT_STRING("{:d}"), "foo");
   \endrst
  */
-#define FMT_STRING(s) FMT_STRING_IMPL(s, efp_fmt::detail::compile_string, )
+#define EFP_FMT_STRING(s) EFP_FMT_STRING_IMPL(s, efp_fmt::detail::compile_string, )
 
 template<size_t width, typename Char, typename OutputIt>
 auto write_codepoint(OutputIt out, char prefix, uint32_t cp) -> OutputIt {
@@ -2084,9 +2084,9 @@ auto write_escaped_cp(OutputIt out, const find_escape_result<Char>& escape) -> O
             c = static_cast<Char>('t');
             break;
         case '"':
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case '\'':
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case '\\':
             *out++ = static_cast<Char>('\\');
             break;
@@ -2144,7 +2144,7 @@ auto write_escaped_char(OutputIt out, Char v) -> OutputIt {
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write_char(OutputIt out, Char value, const format_specs<Char>& specs)
+EFP_FMT_CONSTEXPR auto write_char(OutputIt out, Char value, const format_specs<Char>& specs)
     -> OutputIt {
     bool is_debug = specs.type == presentation_type::debug;
     return write_padded(out, specs, 1, [=](reserve_iterator<OutputIt> it) {
@@ -2156,7 +2156,7 @@ FMT_CONSTEXPR auto write_char(OutputIt out, Char value, const format_specs<Char>
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto
+EFP_FMT_CONSTEXPR auto
 write(OutputIt out, Char value, const format_specs<Char>& specs, locale_ref loc = {}) -> OutputIt {
     // char is formatted as unsigned char for consistency across platforms.
     using unsigned_type = efp::Conditional<efp::IsSame<Char, char>::value, unsigned char, unsigned>;
@@ -2171,7 +2171,7 @@ struct write_int_data {
     size_t size;
     size_t padding;
 
-    FMT_CONSTEXPR write_int_data(int num_digits, unsigned prefix, const format_specs<Char>& specs)
+    EFP_FMT_CONSTEXPR write_int_data(int num_digits, unsigned prefix, const format_specs<Char>& specs)
         : size((prefix >> 24) + to_unsigned(num_digits)), padding(0) {
         if (specs.align == align::numeric) {
             auto width = to_unsigned(specs.width);
@@ -2191,7 +2191,7 @@ struct write_int_data {
 // where <digits> are written by write_digits(it).
 // prefix contains chars in three lower bytes and the size in the fourth byte.
 template<typename OutputIt, typename Char, typename W>
-FMT_CONSTEXPR FMT_INLINE auto write_int(
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto write_int(
     OutputIt out,
     int num_digits,
     unsigned prefix,
@@ -2320,7 +2320,7 @@ auto write_int(
 }
 
 // Writes a localized value.
-FMT_API auto write_loc(appender out, loc_value value, const format_specs<>& specs, locale_ref loc)
+EFP_FMT_API auto write_loc(appender out, loc_value value, const format_specs<>& specs, locale_ref loc)
     -> bool;
 
 template<typename OutputIt, typename Char>
@@ -2328,7 +2328,7 @@ inline auto write_loc(OutputIt, loc_value, const format_specs<Char>&, locale_ref
     return false;
 }
 
-FMT_CONSTEXPR inline void prefix_append(unsigned& prefix, unsigned value) {
+EFP_FMT_CONSTEXPR inline void prefix_append(unsigned& prefix, unsigned value) {
     prefix |= prefix != 0 ? value << 8 : value;
     prefix += (1u + (value > 0xff ? 1 : 0)) << 24;
 }
@@ -2340,7 +2340,7 @@ struct write_int_arg {
 };
 
 template<typename T>
-FMT_CONSTEXPR auto make_write_int_arg(T value, sign_t sign)
+EFP_FMT_CONSTEXPR auto make_write_int_arg(T value, sign_t sign)
     -> write_int_arg<uint32_or_64_or_128_t<T>> {
     auto prefix = 0u;
     auto abs_value = static_cast<uint32_or_64_or_128_t<T>>(value);
@@ -2362,7 +2362,7 @@ struct loc_writer {
     efp::String grouping;
     efp::BasicString<Char> decimal_point;
 
-    template<typename T, FMT_ENABLE_IF(is_integer<T>::value)>
+    template<typename T, EFP_FMT_ENABLE_IF(is_integer<T>::value)>
     auto operator()(T value) -> bool {
         auto arg = make_write_int_arg(value, specs.sign);
         write_int(
@@ -2375,14 +2375,14 @@ struct loc_writer {
         return true;
     }
 
-    template<typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
+    template<typename T, EFP_FMT_ENABLE_IF(!is_integer<T>::value)>
     auto operator()(T) -> bool {
         return false;
     }
 };
 
 template<typename Char, typename OutputIt, typename T>
-FMT_CONSTEXPR FMT_INLINE auto
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto
 write_int(OutputIt out, write_int_arg<T> arg, const format_specs<Char>& specs, locale_ref)
     -> OutputIt {
     static_assert(efp::IsSame<T, uint32_or_64_or_128_t<T>>::value, "");
@@ -2435,7 +2435,7 @@ write_int(OutputIt out, write_int_arg<T> arg, const format_specs<Char>& specs, l
 }
 
 template<typename Char, typename OutputIt, typename T>
-FMT_CONSTEXPR FMT_NOINLINE auto write_int_noinline(
+EFP_FMT_CONSTEXPR EFP_FMT_NOINLINE auto write_int_noinline(
     OutputIt out,
     write_int_arg<T> arg,
     const format_specs<Char>& specs,
@@ -2448,11 +2448,11 @@ template<
     typename Char,
     typename OutputIt,
     typename T,
-    FMT_ENABLE_IF(
+    EFP_FMT_ENABLE_IF(
         is_integral<T>::value && !efp::IsSame<T, bool>::value
         && efp::IsSame<OutputIt, buffer_appender<Char>>::value
     )>
-FMT_CONSTEXPR FMT_INLINE auto
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto
 write(OutputIt out, T value, const format_specs<Char>& specs, locale_ref loc) -> OutputIt {
     if (specs.localized && write_loc(out, value, specs, loc))
         return out;
@@ -2464,11 +2464,11 @@ template<
     typename Char,
     typename OutputIt,
     typename T,
-    FMT_ENABLE_IF(
+    EFP_FMT_ENABLE_IF(
         is_integral<T>::value && !efp::IsSame<T, bool>::value
         && !efp::IsSame<OutputIt, buffer_appender<Char>>::value
     )>
-FMT_CONSTEXPR FMT_INLINE auto
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto
 write(OutputIt out, T value, const format_specs<Char>& specs, locale_ref loc) -> OutputIt {
     if (specs.localized && write_loc(out, value, specs, loc))
         return out;
@@ -2486,42 +2486,42 @@ class counting_iterator {
     using difference_type = std::ptrdiff_t;
     using pointer = void;
     using reference = void;
-    FMT_UNCHECKED_ITERATOR(counting_iterator);
+    EFP_FMT_UNCHECKED_ITERATOR(counting_iterator);
 
     struct value_type {
         template<typename T>
-        FMT_CONSTEXPR void operator=(const T&) {}
+        EFP_FMT_CONSTEXPR void operator=(const T&) {}
     };
 
-    FMT_CONSTEXPR counting_iterator() : count_(0) {}
+    EFP_FMT_CONSTEXPR counting_iterator() : count_(0) {}
 
-    FMT_CONSTEXPR size_t count() const {
+    EFP_FMT_CONSTEXPR size_t count() const {
         return count_;
     }
 
-    FMT_CONSTEXPR counting_iterator& operator++() {
+    EFP_FMT_CONSTEXPR counting_iterator& operator++() {
         ++count_;
         return *this;
     }
 
-    FMT_CONSTEXPR counting_iterator operator++(int) {
+    EFP_FMT_CONSTEXPR counting_iterator operator++(int) {
         auto it = *this;
         ++*this;
         return it;
     }
 
-    FMT_CONSTEXPR friend counting_iterator operator+(counting_iterator it, difference_type n) {
+    EFP_FMT_CONSTEXPR friend counting_iterator operator+(counting_iterator it, difference_type n) {
         it.count_ += static_cast<size_t>(n);
         return it;
     }
 
-    FMT_CONSTEXPR value_type operator*() const {
+    EFP_FMT_CONSTEXPR value_type operator*() const {
         return {};
     }
 };
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s, const format_specs<Char>& specs)
+EFP_FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s, const format_specs<Char>& specs)
     -> OutputIt {
     auto data = s.data();
     auto size = s.size();
@@ -2543,7 +2543,7 @@ FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> s, const format_s
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(
+EFP_FMT_CONSTEXPR auto write(
     OutputIt out,
     basic_string_view<type_identity_t<Char>> s,
     const format_specs<Char>& specs,
@@ -2553,7 +2553,7 @@ FMT_CONSTEXPR auto write(
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(OutputIt out, const Char* s, const format_specs<Char>& specs, locale_ref)
+EFP_FMT_CONSTEXPR auto write(OutputIt out, const Char* s, const format_specs<Char>& specs, locale_ref)
     -> OutputIt {
     if (specs.type == presentation_type::pointer)
         return write_ptr<Char>(out, bit_cast<uintptr_t>(s), &specs);
@@ -2566,10 +2566,10 @@ template<
     typename Char,
     typename OutputIt,
     typename T,
-    FMT_ENABLE_IF(
+    EFP_FMT_ENABLE_IF(
         is_integral<T>::value && !efp::IsSame<T, bool>::value && !efp::IsSame<T, Char>::value
     )>
-FMT_CONSTEXPR auto write(OutputIt out, T value) -> OutputIt {
+EFP_FMT_CONSTEXPR auto write(OutputIt out, T value) -> OutputIt {
     auto abs_value = static_cast<uint32_or_64_or_128_t<T>>(value);
     bool negative = is_negative(value);
     // Don't do -abs_value since it trips unsigned-integer-overflow sanitizer.
@@ -2592,9 +2592,9 @@ FMT_CONSTEXPR auto write(OutputIt out, T value) -> OutputIt {
 
 // DEPRECATED!
 template<typename Char>
-FMT_CONSTEXPR auto parse_align(const Char* begin, const Char* end, format_specs<Char>& specs)
+EFP_FMT_CONSTEXPR auto parse_align(const Char* begin, const Char* end, format_specs<Char>& specs)
     -> const Char* {
-    FMT_ASSERT(begin != end, "");
+    EFP_FMT_ASSERT(begin != end, "");
     auto align = align::none;
     auto p = begin + code_point_length(begin);
     if (end - p <= 0)
@@ -2654,7 +2654,7 @@ struct float_specs {
 };
 
 template<typename ErrorHandler = error_handler, typename Char>
-FMT_CONSTEXPR auto parse_float_type_spec(const format_specs<Char>& specs, ErrorHandler&& eh = {})
+EFP_FMT_CONSTEXPR auto parse_float_type_spec(const format_specs<Char>& specs, ErrorHandler&& eh = {})
     -> float_specs {
     auto result = float_specs();
     result.showpoint = specs.alt;
@@ -2665,27 +2665,27 @@ FMT_CONSTEXPR auto parse_float_type_spec(const format_specs<Char>& specs, ErrorH
             break;
         case presentation_type::general_upper:
             result.upper = true;
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case presentation_type::general_lower:
             result.format = float_format::general;
             break;
         case presentation_type::exp_upper:
             result.upper = true;
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case presentation_type::exp_lower:
             result.format = float_format::exp;
             result.showpoint |= specs.precision != 0;
             break;
         case presentation_type::fixed_upper:
             result.upper = true;
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case presentation_type::fixed_lower:
             result.format = float_format::fixed;
             result.showpoint |= specs.precision != 0;
             break;
         case presentation_type::hexfloat_upper:
             result.upper = true;
-            FMT_FALLTHROUGH;
+            EFP_FMT_FALLTHROUGH;
         case presentation_type::hexfloat_lower:
             result.format = float_format::hex;
             break;
@@ -2697,7 +2697,7 @@ FMT_CONSTEXPR auto parse_float_type_spec(const format_specs<Char>& specs, ErrorH
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR20 auto
+EFP_FMT_CONSTEXPR20 auto
 write_nonfinite(OutputIt out, bool isnan, format_specs<Char> specs, const float_specs& fspecs)
     -> OutputIt {
     auto str = isnan ? (fspecs.upper ? "NAN" : "nan") : (fspecs.upper ? "INF" : "inf");
@@ -2744,7 +2744,7 @@ inline auto write_significand(OutputIt out, UInt significand, int significand_si
 }
 
 template<typename Char, typename OutputIt, typename T, typename Grouping>
-FMT_CONSTEXPR20 auto write_significand(
+EFP_FMT_CONSTEXPR20 auto write_significand(
     OutputIt out,
     T significand,
     int significand_size,
@@ -2761,7 +2761,7 @@ FMT_CONSTEXPR20 auto write_significand(
     return grouping.apply(out, string_view(buffer.data(), buffer.size()));
 }
 
-template<typename Char, typename UInt, FMT_ENABLE_IF(std::is_integral<UInt>::value)>
+template<typename Char, typename UInt, EFP_FMT_ENABLE_IF(std::is_integral<UInt>::value)>
 inline auto write_significand(
     Char* out,
     UInt significand,
@@ -2792,7 +2792,7 @@ template<
     typename OutputIt,
     typename UInt,
     typename Char,
-    FMT_ENABLE_IF(!std::is_pointer<efp::CVRefRemoved<OutputIt>>::value)>
+    EFP_FMT_ENABLE_IF(!std::is_pointer<efp::CVRefRemoved<OutputIt>>::value)>
 inline auto write_significand(
     OutputIt out,
     UInt significand,
@@ -2808,7 +2808,7 @@ inline auto write_significand(
 }
 
 template<typename OutputIt, typename Char>
-FMT_CONSTEXPR auto write_significand(
+EFP_FMT_CONSTEXPR auto write_significand(
     OutputIt out,
     const char* significand,
     int significand_size,
@@ -2827,7 +2827,7 @@ FMT_CONSTEXPR auto write_significand(
 }
 
 template<typename OutputIt, typename Char, typename T, typename Grouping>
-FMT_CONSTEXPR20 auto write_significand(
+EFP_FMT_CONSTEXPR20 auto write_significand(
     OutputIt out,
     T significand,
     int significand_size,
@@ -2855,7 +2855,7 @@ template<
     typename DecimalFP,
     typename Char,
     typename Grouping = digit_grouping<Char>>
-FMT_CONSTEXPR20 auto do_write_float(
+EFP_FMT_CONSTEXPR20 auto do_write_float(
     OutputIt out,
     const DecimalFP& f,
     const format_specs<Char>& specs,
@@ -2990,7 +2990,7 @@ class fallback_digit_grouping {
 };
 
 template<typename OutputIt, typename DecimalFP, typename Char>
-FMT_CONSTEXPR20 auto write_float(
+EFP_FMT_CONSTEXPR20 auto write_float(
     OutputIt out,
     const DecimalFP& f,
     const format_specs<Char>& specs,
@@ -3021,23 +3021,23 @@ struct has_isfinite: efp::False {};
 template<typename T>
 struct has_isfinite<T, efp::EnableIf<sizeof(std::isfinite(T())) != 0>>: efp::True {};
 
-template<typename T, FMT_ENABLE_IF(std::is_floating_point<T>::value&& has_isfinite<T>::value)>
-FMT_CONSTEXPR20 bool isfinite(T value) {
+template<typename T, EFP_FMT_ENABLE_IF(std::is_floating_point<T>::value&& has_isfinite<T>::value)>
+EFP_FMT_CONSTEXPR20 bool isfinite(T value) {
     constexpr T inf = T(efp::NumericLimits<double>::infinity());
     if (is_constant_evaluated())
         return !detail::isnan(value) && value < inf && value > -inf;
     return std::isfinite(value);
 }
 
-template<typename T, FMT_ENABLE_IF(!has_isfinite<T>::value)>
-FMT_CONSTEXPR bool isfinite(T value) {
+template<typename T, EFP_FMT_ENABLE_IF(!has_isfinite<T>::value)>
+EFP_FMT_CONSTEXPR bool isfinite(T value) {
     T inf = T(efp::NumericLimits<double>::infinity());
     // std::isfinite doesn't support __float128.
     return !detail::isnan(value) && value < inf && value > -inf;
 }
 
-template<typename T, FMT_ENABLE_IF(is_floating_point<T>::value)>
-FMT_INLINE FMT_CONSTEXPR bool signbit(T value) {
+template<typename T, EFP_FMT_ENABLE_IF(is_floating_point<T>::value)>
+EFP_FMT_INLINE EFP_FMT_CONSTEXPR bool signbit(T value) {
     if (is_constant_evaluated()) {
 #ifdef __cpp_if_constexpr
         if constexpr (efp::NumericLimits<double>::is_iec559) {
@@ -3049,11 +3049,11 @@ FMT_INLINE FMT_CONSTEXPR bool signbit(T value) {
     return std::signbit(static_cast<double>(value));
 }
 
-inline FMT_CONSTEXPR20 void adjust_precision(int& precision, int exp10) {
+inline EFP_FMT_CONSTEXPR20 void adjust_precision(int& precision, int exp10) {
     // Adjust fixed precision by exponent because it is relative to decimal
     // point.
     if (exp10 > 0 && precision > max_value<int>() - exp10)
-        FMT_THROW(format_error("number is too big"));
+        EFP_FMT_THROW(format_error("number is too big"));
     precision += exp10;
 }
 
@@ -3069,11 +3069,11 @@ class bigint {
     basic_memory_buffer<bigit, bigits_capacity> bigits_;
     int exp_;
 
-    FMT_CONSTEXPR20 bigit operator[](int index) const {
+    EFP_FMT_CONSTEXPR20 bigit operator[](int index) const {
         return bigits_[to_unsigned(index)];
     }
 
-    FMT_CONSTEXPR20 bigit& operator[](int index) {
+    EFP_FMT_CONSTEXPR20 bigit& operator[](int index) {
         return bigits_[to_unsigned(index)];
     }
 
@@ -3081,13 +3081,13 @@ class bigint {
 
     friend struct formatter<bigint>;
 
-    FMT_CONSTEXPR20 void subtract_bigits(int index, bigit other, bigit& borrow) {
+    EFP_FMT_CONSTEXPR20 void subtract_bigits(int index, bigit other, bigit& borrow) {
         auto result = static_cast<double_bigit>((*this)[index]) - other - borrow;
         (*this)[index] = static_cast<bigit>(result);
         borrow = static_cast<bigit>(result >> (bigit_bits * 2 - 1));
     }
 
-    FMT_CONSTEXPR20 void remove_leading_zeros() {
+    EFP_FMT_CONSTEXPR20 void remove_leading_zeros() {
         int num_bigits = static_cast<int>(bigits_.size()) - 1;
         while (num_bigits > 0 && (*this)[num_bigits] == 0)
             --num_bigits;
@@ -3095,9 +3095,9 @@ class bigint {
     }
 
     // Computes *this -= other assuming aligned bigints and *this >= other.
-    FMT_CONSTEXPR20 void subtract_aligned(const bigint& other) {
-        FMT_ASSERT(other.exp_ >= exp_, "unaligned bigints");
-        FMT_ASSERT(compare(*this, other) >= 0, "");
+    EFP_FMT_CONSTEXPR20 void subtract_aligned(const bigint& other) {
+        EFP_FMT_ASSERT(other.exp_ >= exp_, "unaligned bigints");
+        EFP_FMT_ASSERT(compare(*this, other) >= 0, "");
         bigit borrow = 0;
         int i = other.exp_ - exp_;
         for (size_t j = 0, n = other.bigits_.size(); j != n; ++i, ++j)
@@ -3107,7 +3107,7 @@ class bigint {
         remove_leading_zeros();
     }
 
-    FMT_CONSTEXPR20 void multiply(uint32_t value) {
+    EFP_FMT_CONSTEXPR20 void multiply(uint32_t value) {
         const double_bigit wide_value = value;
         bigit carry = 0;
         for (size_t i = 0, n = bigits_.size(); i < n; ++i) {
@@ -3121,8 +3121,8 @@ class bigint {
 
     template<
         typename UInt,
-        FMT_ENABLE_IF(efp::IsSame<UInt, uint64_t>::value || efp::IsSame<UInt, uint128_t>::value)>
-    FMT_CONSTEXPR20 void multiply(UInt value) {
+        EFP_FMT_ENABLE_IF(efp::IsSame<UInt, uint64_t>::value || efp::IsSame<UInt, uint128_t>::value)>
+    EFP_FMT_CONSTEXPR20 void multiply(UInt value) {
         using half_uint = efp::Conditional<efp::IsSame<UInt, uint128_t>::value, uint64_t, uint32_t>;
         const int shift = num_bits<half_uint>() - bigit_bits;
         const UInt lower = static_cast<half_uint>(value);
@@ -3141,8 +3141,8 @@ class bigint {
 
     template<
         typename UInt,
-        FMT_ENABLE_IF(efp::IsSame<UInt, uint64_t>::value || efp::IsSame<UInt, uint128_t>::value)>
-    FMT_CONSTEXPR20 void assign(UInt n) {
+        EFP_FMT_ENABLE_IF(efp::IsSame<UInt, uint64_t>::value || efp::IsSame<UInt, uint128_t>::value)>
+    EFP_FMT_CONSTEXPR20 void assign(UInt n) {
         size_t num_bigits = 0;
         do {
             bigits_[num_bigits++] = static_cast<bigit>(n);
@@ -3153,7 +3153,7 @@ class bigint {
     }
 
   public:
-    FMT_CONSTEXPR20 bigint() : exp_(0) {}
+    EFP_FMT_CONSTEXPR20 bigint() : exp_(0) {}
 
     explicit bigint(uint64_t n) {
         assign(n);
@@ -3162,7 +3162,7 @@ class bigint {
     bigint(const bigint&) = delete;
     void operator=(const bigint&) = delete;
 
-    FMT_CONSTEXPR20 void assign(const bigint& other) {
+    EFP_FMT_CONSTEXPR20 void assign(const bigint& other) {
         auto size = other.bigits_.size();
         bigits_.resize(size);
         auto data = other.bigits_.data();
@@ -3171,17 +3171,17 @@ class bigint {
     }
 
     template<typename Int>
-    FMT_CONSTEXPR20 void operator=(Int n) {
-        FMT_ASSERT(n > 0, "");
+    EFP_FMT_CONSTEXPR20 void operator=(Int n) {
+        EFP_FMT_ASSERT(n > 0, "");
         assign(uint64_or_128_t<Int>(n));
     }
 
-    FMT_CONSTEXPR20 int num_bigits() const {
+    EFP_FMT_CONSTEXPR20 int num_bigits() const {
         return static_cast<int>(bigits_.size()) + exp_;
     }
 
-    FMT_NOINLINE FMT_CONSTEXPR20 bigint& operator<<=(int shift) {
-        FMT_ASSERT(shift >= 0, "");
+    EFP_FMT_NOINLINE EFP_FMT_CONSTEXPR20 bigint& operator<<=(int shift) {
+        EFP_FMT_ASSERT(shift >= 0, "");
         exp_ += shift / bigit_bits;
         shift %= bigit_bits;
         if (shift == 0)
@@ -3198,13 +3198,13 @@ class bigint {
     }
 
     template<typename Int>
-    FMT_CONSTEXPR20 bigint& operator*=(Int value) {
-        FMT_ASSERT(value > 0, "");
+    EFP_FMT_CONSTEXPR20 bigint& operator*=(Int value) {
+        EFP_FMT_ASSERT(value > 0, "");
         multiply(uint32_or_64_or_128_t<Int>(value));
         return *this;
     }
 
-    friend FMT_CONSTEXPR20 int compare(const bigint& lhs, const bigint& rhs) {
+    friend EFP_FMT_CONSTEXPR20 int compare(const bigint& lhs, const bigint& rhs) {
         int num_lhs_bigits = lhs.num_bigits(), num_rhs_bigits = rhs.num_bigits();
         if (num_lhs_bigits != num_rhs_bigits)
             return num_lhs_bigits > num_rhs_bigits ? 1 : -1;
@@ -3224,7 +3224,7 @@ class bigint {
     }
 
     // Returns compare(lhs1 + lhs2, rhs).
-    friend FMT_CONSTEXPR20 int
+    friend EFP_FMT_CONSTEXPR20 int
     add_compare(const bigint& lhs1, const bigint& lhs2, const bigint& rhs) {
         auto minimum = [](int a, int b) { return a < b ? a : b; };
         auto maximum = [](int a, int b) { return a > b ? a : b; };
@@ -3253,8 +3253,8 @@ class bigint {
     }
 
     // Assigns pow(10, exp) to this bigint.
-    FMT_CONSTEXPR20 void assign_pow10(int exp) {
-        FMT_ASSERT(exp >= 0, "");
+    EFP_FMT_CONSTEXPR20 void assign_pow10(int exp) {
+        EFP_FMT_ASSERT(exp >= 0, "");
         if (exp == 0)
             return *this = 1;
         // Find the top bit.
@@ -3275,7 +3275,7 @@ class bigint {
         *this <<= exp;  // Multiply by pow(2, exp) by shifting.
     }
 
-    FMT_CONSTEXPR20 void square() {
+    EFP_FMT_CONSTEXPR20 void square() {
         int num_bigits = static_cast<int>(bigits_.size());
         int num_result_bigits = 2 * num_bigits;
         basic_memory_buffer<bigit, bigits_capacity> n(efp::move(bigits_));
@@ -3304,7 +3304,7 @@ class bigint {
 
     // If this bigint has a bigger exponent than other, adds trailing zero to make
     // exponents equal. This simplifies some operations such as subtraction.
-    FMT_CONSTEXPR20 void align(const bigint& other) {
+    EFP_FMT_CONSTEXPR20 void align(const bigint& other) {
         int exp_difference = exp_ - other.exp_;
         if (exp_difference <= 0)
             return;
@@ -3318,11 +3318,11 @@ class bigint {
 
     // Divides this bignum by divisor, assigning the remainder to this and
     // returning the quotient.
-    FMT_CONSTEXPR20 int divmod_assign(const bigint& divisor) {
-        FMT_ASSERT(this != &divisor, "");
+    EFP_FMT_CONSTEXPR20 int divmod_assign(const bigint& divisor) {
+        EFP_FMT_ASSERT(this != &divisor, "");
         if (compare(*this, divisor) < 0)
             return 0;
-        FMT_ASSERT(divisor.bigits_[divisor.bigits_.size() - 1u] != 0, "");
+        EFP_FMT_ASSERT(divisor.bigits_[divisor.bigits_.size() - 1u] != 0, "");
         align(divisor);
         int quotient = 0;
         do {
@@ -3343,7 +3343,7 @@ enum dragon {
 // Formats a floating-point number using a variation of the Fixed-Precision
 // Positive Floating-Point Printout ((FPP)^2) algorithm by Steele & White:
 // https://fmt.dev/papers/p372-steele.pdf.
-FMT_CONSTEXPR20 inline void format_dragon(
+EFP_FMT_CONSTEXPR20 inline void format_dragon(
     basic_fp<uint128_t> value,
     unsigned flags,
     int num_digits,
@@ -3483,8 +3483,8 @@ FMT_CONSTEXPR20 inline void format_dragon(
 }
 
 // Formats a floating-point number using the hexfloat format.
-template<typename Float, FMT_ENABLE_IF(!is_double_double<Float>::value)>
-FMT_CONSTEXPR20 void
+template<typename Float, EFP_FMT_ENABLE_IF(!is_double_double<Float>::value)>
+EFP_FMT_CONSTEXPR20 void
 format_hexfloat(Float value, int precision, float_specs specs, buffer<char>& buf) {
     // float is passed as double to reduce the number of instantiations and to
     // simplify implementation.
@@ -3566,8 +3566,8 @@ format_hexfloat(Float value, int precision, float_specs specs, buffer<char>& buf
     format_decimal<char>(appender(buf), abs_e, detail::count_digits(abs_e));
 }
 
-template<typename Float, FMT_ENABLE_IF(is_double_double<Float>::value)>
-FMT_CONSTEXPR20 void
+template<typename Float, EFP_FMT_ENABLE_IF(is_double_double<Float>::value)>
+EFP_FMT_CONSTEXPR20 void
 format_hexfloat(Float value, int precision, float_specs specs, buffer<char>& buf) {
     format_hexfloat(static_cast<double>(value), precision, specs, buf);
 }
@@ -3584,11 +3584,11 @@ constexpr uint32_t fractional_part_rounding_thresholds(int index) {
 }
 
 template<typename Float>
-FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs, buffer<char>& buf)
+EFP_FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs, buffer<char>& buf)
     -> int {
     // float is passed as double to reduce the number of instantiations.
     static_assert(!efp::IsSame<Float, float>::value, "");
-    FMT_ASSERT(value >= 0, "value is negative");
+    EFP_FMT_ASSERT(value >= 0, "value is negative");
     auto converted_value = convert_float(value);
 
     const bool fixed = specs.format == float_format::fixed;
@@ -3645,9 +3645,9 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
             significand <<= 1;
         } else {
             // Normalize subnormal inputs.
-            FMT_ASSERT(significand != 0, "zeros should not appear here");
+            EFP_FMT_ASSERT(significand != 0, "zeros should not appear here");
             int shift = countl_zero(significand);
-            FMT_ASSERT(shift >= num_bits<uint64_t>() - num_significand_bits<double>(), "");
+            EFP_FMT_ASSERT(shift >= num_bits<uint64_t>() - num_significand_bits<double>(), "");
             shift -= (num_bits<uint64_t>() - num_significand_bits<double>() - 2);
             exponent =
                 (efp::NumericLimits<double>::min_exponent - num_significand_bits<double>()) - shift;
@@ -3894,7 +3894,7 @@ FMT_CONSTEXPR20 auto format_float(Float value, int precision, float_specs specs,
 }
 
 template<typename Char, typename OutputIt, typename T>
-FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs<Char> specs, locale_ref loc)
+EFP_FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs<Char> specs, locale_ref loc)
     -> OutputIt {
     float_specs fspecs = parse_float_type_spec(specs);
     fspecs.sign = specs.sign;
@@ -3942,8 +3942,8 @@ FMT_CONSTEXPR20 auto write_float(OutputIt out, T value, format_specs<Char> specs
     return write_float(out, f, specs, fspecs, loc);
 }
 
-template<typename Char, typename OutputIt, typename T, FMT_ENABLE_IF(is_floating_point<T>::value)>
-FMT_CONSTEXPR20 auto write(OutputIt out, T value, format_specs<Char> specs, locale_ref loc = {})
+template<typename Char, typename OutputIt, typename T, EFP_FMT_ENABLE_IF(is_floating_point<T>::value)>
+EFP_FMT_CONSTEXPR20 auto write(OutputIt out, T value, format_specs<Char> specs, locale_ref loc = {})
     -> OutputIt {
     if (const_check(!is_supported_floating_point(value)))
         return out;
@@ -3952,8 +3952,8 @@ FMT_CONSTEXPR20 auto write(OutputIt out, T value, format_specs<Char> specs, loca
         : write_float(out, value, specs, loc);
 }
 
-template<typename Char, typename OutputIt, typename T, FMT_ENABLE_IF(is_fast_float<T>::value)>
-FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
+template<typename Char, typename OutputIt, typename T, EFP_FMT_ENABLE_IF(is_fast_float<T>::value)>
+EFP_FMT_CONSTEXPR20 auto write(OutputIt out, T value) -> OutputIt {
     if (is_constant_evaluated())
         return write(out, value, format_specs<Char>());
     if (const_check(!is_supported_floating_point(value)))
@@ -3980,30 +3980,30 @@ template<
     typename Char,
     typename OutputIt,
     typename T,
-    FMT_ENABLE_IF(is_floating_point<T>::value && !is_fast_float<T>::value)>
+    EFP_FMT_ENABLE_IF(is_floating_point<T>::value && !is_fast_float<T>::value)>
 inline auto write(OutputIt out, T value) -> OutputIt {
     return write(out, value, format_specs<Char>());
 }
 
 template<typename Char, typename OutputIt>
 auto write(OutputIt out, monostate, format_specs<Char> = {}, locale_ref = {}) -> OutputIt {
-    FMT_ASSERT(false, "");
+    EFP_FMT_ASSERT(false, "");
     return out;
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> value) -> OutputIt {
+EFP_FMT_CONSTEXPR auto write(OutputIt out, basic_string_view<Char> value) -> OutputIt {
     auto it = reserve(out, value.size());
     it = copy_str_noinline<Char>(value.begin(), value.end(), it);
     return base_iterator(out, it);
 }
 
-template<typename Char, typename OutputIt, typename T, FMT_ENABLE_IF(is_string<T>::value)>
+template<typename Char, typename OutputIt, typename T, EFP_FMT_ENABLE_IF(is_string<T>::value)>
 constexpr auto write(OutputIt out, const T& value) -> OutputIt {
     return write<Char>(out, to_string_view(value));
 }
 
-// FMT_ENABLE_IF() condition separated to workaround an MSVC bug.
+// EFP_FMT_ENABLE_IF() condition separated to workaround an MSVC bug.
 template<
     typename Char,
     typename OutputIt,
@@ -4011,13 +4011,13 @@ template<
     bool check = std::is_enum<T>::value && !efp::IsSame<T, Char>::value
         && mapped_type_constant<T, basic_format_context<OutputIt, Char>>::value
             != type::custom_type,
-    FMT_ENABLE_IF(check)>
-FMT_CONSTEXPR auto write(OutputIt out, T value) -> OutputIt {
+    EFP_FMT_ENABLE_IF(check)>
+EFP_FMT_CONSTEXPR auto write(OutputIt out, T value) -> OutputIt {
     return write<Char>(out, static_cast<underlying_t<T>>(value));
 }
 
-template<typename Char, typename OutputIt, typename T, FMT_ENABLE_IF(efp::IsSame<T, bool>::value)>
-FMT_CONSTEXPR auto
+template<typename Char, typename OutputIt, typename T, EFP_FMT_ENABLE_IF(efp::IsSame<T, bool>::value)>
+EFP_FMT_CONSTEXPR auto
 write(OutputIt out, T value, const format_specs<Char>& specs = {}, locale_ref = {}) -> OutputIt {
     return specs.type != presentation_type::none && specs.type != presentation_type::string
         ? write(out, value ? 1 : 0, specs, {})
@@ -4025,21 +4025,21 @@ write(OutputIt out, T value, const format_specs<Char>& specs = {}, locale_ref = 
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR auto write(OutputIt out, Char value) -> OutputIt {
+EFP_FMT_CONSTEXPR auto write(OutputIt out, Char value) -> OutputIt {
     auto it = reserve(out, 1);
     *it++ = value;
     return base_iterator(out, it);
 }
 
 template<typename Char, typename OutputIt>
-FMT_CONSTEXPR_CHAR_TRAITS auto write(OutputIt out, const Char* value) -> OutputIt {
+EFP_FMT_CONSTEXPR_CHAR_TRAITS auto write(OutputIt out, const Char* value) -> OutputIt {
     if (value)
         return write(out, basic_string_view<Char>(value));
     throw_format_error("string pointer is null");
     return out;
 }
 
-template<typename Char, typename OutputIt, typename T, FMT_ENABLE_IF(efp::IsSame<T, void>::value)>
+template<typename Char, typename OutputIt, typename T, EFP_FMT_ENABLE_IF(efp::IsSame<T, void>::value)>
 auto write(OutputIt out, const T* value, const format_specs<Char>& specs = {}, locale_ref = {})
     -> OutputIt {
     return write_ptr<Char>(out, bit_cast<uintptr_t>(value), &specs);
@@ -4051,7 +4051,7 @@ template<
     typename OutputIt,
     typename T,
     typename Context = basic_format_context<OutputIt, Char>>
-FMT_CONSTEXPR auto write(OutputIt out, const T& value) -> efp::EnableIf<
+EFP_FMT_CONSTEXPR auto write(OutputIt out, const T& value) -> efp::EnableIf<
     std::is_class<T>::value && !is_string<T>::value && !is_floating_point<T>::value
         && !efp::IsSame<T, Char>::value
         && !efp::IsSame<T, efp::CVRefRemoved<decltype(arg_mapper<Context>().map(value))>>::value,
@@ -4064,7 +4064,7 @@ template<
     typename OutputIt,
     typename T,
     typename Context = basic_format_context<OutputIt, Char>>
-FMT_CONSTEXPR auto write(OutputIt out, const T& value)
+EFP_FMT_CONSTEXPR auto write(OutputIt out, const T& value)
     -> efp::EnableIf<mapped_type_constant<T, Context>::value == type::custom_type, OutputIt> {
     auto formatter = typename Context::template formatter_type<T>();
     auto parse_ctx = typename Context::parse_context_type({});
@@ -4107,7 +4107,7 @@ struct arg_formatter {
     locale_ref locale;
 
     template<typename T>
-    FMT_CONSTEXPR FMT_INLINE auto operator()(T value) -> iterator {
+    EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto operator()(T value) -> iterator {
         return detail::write(out, value, specs, locale);
     }
 
@@ -4134,17 +4134,17 @@ struct custom_formatter {
 template<typename ErrorHandler>
 class width_checker {
   public:
-    explicit FMT_CONSTEXPR width_checker(ErrorHandler& eh) : handler_(eh) {}
+    explicit EFP_FMT_CONSTEXPR width_checker(ErrorHandler& eh) : handler_(eh) {}
 
-    template<typename T, FMT_ENABLE_IF(is_integer<T>::value)>
-    FMT_CONSTEXPR auto operator()(T value) -> unsigned long long {
+    template<typename T, EFP_FMT_ENABLE_IF(is_integer<T>::value)>
+    EFP_FMT_CONSTEXPR auto operator()(T value) -> unsigned long long {
         if (is_negative(value))
             handler_.on_error("negative width");
         return static_cast<unsigned long long>(value);
     }
 
-    template<typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
-    FMT_CONSTEXPR auto operator()(T) -> unsigned long long {
+    template<typename T, EFP_FMT_ENABLE_IF(!is_integer<T>::value)>
+    EFP_FMT_CONSTEXPR auto operator()(T) -> unsigned long long {
         handler_.on_error("width is not integer");
         return 0;
     }
@@ -4156,17 +4156,17 @@ class width_checker {
 template<typename ErrorHandler>
 class precision_checker {
   public:
-    explicit FMT_CONSTEXPR precision_checker(ErrorHandler& eh) : handler_(eh) {}
+    explicit EFP_FMT_CONSTEXPR precision_checker(ErrorHandler& eh) : handler_(eh) {}
 
-    template<typename T, FMT_ENABLE_IF(is_integer<T>::value)>
-    FMT_CONSTEXPR auto operator()(T value) -> unsigned long long {
+    template<typename T, EFP_FMT_ENABLE_IF(is_integer<T>::value)>
+    EFP_FMT_CONSTEXPR auto operator()(T value) -> unsigned long long {
         if (is_negative(value))
             handler_.on_error("negative precision");
         return static_cast<unsigned long long>(value);
     }
 
-    template<typename T, FMT_ENABLE_IF(!is_integer<T>::value)>
-    FMT_CONSTEXPR auto operator()(T) -> unsigned long long {
+    template<typename T, EFP_FMT_ENABLE_IF(!is_integer<T>::value)>
+    EFP_FMT_CONSTEXPR auto operator()(T) -> unsigned long long {
         handler_.on_error("precision is not integer");
         return 0;
     }
@@ -4176,7 +4176,7 @@ class precision_checker {
 };
 
 template<template<typename> class Handler, typename FormatArg, typename ErrorHandler>
-FMT_CONSTEXPR auto get_dynamic_spec(FormatArg arg, ErrorHandler eh) -> int {
+EFP_FMT_CONSTEXPR auto get_dynamic_spec(FormatArg arg, ErrorHandler eh) -> int {
     unsigned long long value = visit_format_arg(Handler<ErrorHandler>(eh), arg);
     if (value > to_unsigned(max_value<int>()))
         eh.on_error("number is too big");
@@ -4184,7 +4184,7 @@ FMT_CONSTEXPR auto get_dynamic_spec(FormatArg arg, ErrorHandler eh) -> int {
 }
 
 template<typename Context, typename ID>
-FMT_CONSTEXPR auto get_arg(Context& ctx, ID id) -> decltype(ctx.arg(id)) {
+EFP_FMT_CONSTEXPR auto get_arg(Context& ctx, ID id) -> decltype(ctx.arg(id)) {
     auto arg = ctx.arg(id);
     if (!arg)
         ctx.on_error("argument not found");
@@ -4192,7 +4192,7 @@ FMT_CONSTEXPR auto get_arg(Context& ctx, ID id) -> decltype(ctx.arg(id)) {
 }
 
 template<template<typename> class Handler, typename Context>
-FMT_CONSTEXPR void
+EFP_FMT_CONSTEXPR void
 handle_dynamic_spec(int& value, arg_ref<typename Context::char_type> ref, Context& ctx) {
     switch (ref.kind) {
         case arg_id_kind::none:
@@ -4208,8 +4208,8 @@ handle_dynamic_spec(int& value, arg_ref<typename Context::char_type> ref, Contex
     }
 }
 
-#if FMT_USE_USER_DEFINED_LITERALS
-    #if FMT_USE_NONTYPE_TEMPLATE_ARGS
+#if EFP_FMT_USE_USER_DEFINED_LITERALS
+    #if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
 template<typename T, typename Char, size_t N, efp_fmt::detail_exported::fixed_string<Char, N> Str>
 struct statically_named_arg: view {
     static constexpr auto name = Str.data;
@@ -4243,7 +4243,7 @@ struct udl_arg {
     }
 };
     #endif
-#endif  // FMT_USE_USER_DEFINED_LITERALS
+#endif  // EFP_FMT_USE_USER_DEFINED_LITERALS
 
 template<typename Locale, typename Char>
 auto vformat(
@@ -4258,12 +4258,12 @@ auto vformat(
 
 using format_func = void (*)(detail::buffer<char>&, int, const char*);
 
-FMT_API void format_error_code(buffer<char>& out, int error_code, string_view message) noexcept;
+EFP_FMT_API void format_error_code(buffer<char>& out, int error_code, string_view message) noexcept;
 
-FMT_API void report_error(format_func func, int error_code, const char* message) noexcept;
+EFP_FMT_API void report_error(format_func func, int error_code, const char* message) noexcept;
 }  // namespace detail
 
-FMT_API auto vsystem_error(int error_code, string_view format_str, format_args args)
+EFP_FMT_API auto vsystem_error(int error_code, string_view format_str, format_args args)
     -> std::system_error;
 
 /**
@@ -4304,12 +4304,12 @@ auto system_error(int error_code, format_string<T...> fmt, T&&... args) -> std::
   *error_code* is a system error code as given by ``errno``.
   \endrst
  */
-FMT_API void
+EFP_FMT_API void
 format_system_error(detail::buffer<char>& out, int error_code, const char* message) noexcept;
 
 // Reports a system error without throwing an exception.
 // Can be used to report errors from destructors.
-FMT_API void report_system_error(int error_code, const char* message) noexcept;
+EFP_FMT_API void report_system_error(int error_code, const char* message) noexcept;
 
 /** Fast integer formatter. */
 class format_int {
@@ -4397,21 +4397,21 @@ struct formatter<T, Char, efp::EnableIf<detail::has_format_as<T>::value>>:
     }
 };
 
-#define FMT_FORMAT_AS(Type, Base) \
+#define EFP_FMT_FORMAT_AS(Type, Base) \
     template<typename Char> \
     struct formatter<Type, Char>: formatter<Base, Char> {}
 
-FMT_FORMAT_AS(signed char, int);
-FMT_FORMAT_AS(unsigned char, unsigned);
-FMT_FORMAT_AS(short, int);
-FMT_FORMAT_AS(unsigned short, unsigned);
-FMT_FORMAT_AS(long, detail::long_type);
-FMT_FORMAT_AS(unsigned long, detail::ulong_type);
-FMT_FORMAT_AS(Char*, const Char*);
-FMT_FORMAT_AS(efp::BasicString<Char>, basic_string_view<Char>);
-FMT_FORMAT_AS(std::nullptr_t, const void*);
-FMT_FORMAT_AS(detail::std_string_view<Char>, basic_string_view<Char>);
-FMT_FORMAT_AS(void*, const void*);
+EFP_FMT_FORMAT_AS(signed char, int);
+EFP_FMT_FORMAT_AS(unsigned char, unsigned);
+EFP_FMT_FORMAT_AS(short, int);
+EFP_FMT_FORMAT_AS(unsigned short, unsigned);
+EFP_FMT_FORMAT_AS(long, detail::long_type);
+EFP_FMT_FORMAT_AS(unsigned long, detail::ulong_type);
+EFP_FMT_FORMAT_AS(Char*, const Char*);
+EFP_FMT_FORMAT_AS(efp::BasicString<Char>, basic_string_view<Char>);
+EFP_FMT_FORMAT_AS(std::nullptr_t, const void*);
+EFP_FMT_FORMAT_AS(detail::std_string_view<Char>, basic_string_view<Char>);
+EFP_FMT_FORMAT_AS(void*, const void*);
 
 template<typename Char, size_t N>
 struct formatter<Char[N], Char>: formatter<basic_string_view<Char>, Char> {};
@@ -4457,7 +4457,7 @@ constexpr auto underlying(Enum e) noexcept -> underlying_t<Enum> {
 }
 
 namespace enums {
-template<typename Enum, FMT_ENABLE_IF(std::is_enum<Enum>::value)>
+template<typename Enum, EFP_FMT_ENABLE_IF(std::is_enum<Enum>::value)>
 constexpr auto format_as(Enum e) noexcept -> underlying_t<Enum> {
     return static_cast<underlying_t<Enum>>(e);
 }
@@ -4479,7 +4479,7 @@ struct formatter<bytes> {
 
   public:
     template<typename ParseContext>
-    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const char* {
+    EFP_FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const char* {
         return parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, detail::type::string_type);
     }
 
@@ -4524,7 +4524,7 @@ struct formatter<group_digits_view<T>>: formatter<T> {
 
   public:
     template<typename ParseContext>
-    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const char* {
+    EFP_FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const char* {
         return parse_format_specs(ctx.begin(), ctx.end(), specs_, ctx, detail::type::int_type);
     }
 
@@ -4554,7 +4554,7 @@ struct nested_view {
 
 template<typename T>
 struct formatter<nested_view<T>> {
-    FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> const char* {
+    EFP_FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> const char* {
         return ctx.begin();
     }
 
@@ -4574,7 +4574,7 @@ struct nested_formatter {
   public:
     constexpr nested_formatter() : width_(0), align_(align_t::none) {}
 
-    FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> const char* {
+    EFP_FMT_CONSTEXPR auto parse(format_parse_context& ctx) -> const char* {
         auto specs = detail::dynamic_format_specs<char>();
         auto it = parse_format_specs(ctx.begin(), ctx.end(), specs, ctx, detail::type::none_type);
         width_ = specs.width;
@@ -4625,7 +4625,7 @@ struct formatter<join_view<It, Sentinel, Char>, Char> {
 
   public:
     template<typename ParseContext>
-    FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char* {
+    EFP_FMT_CONSTEXPR auto parse(ParseContext& ctx) -> const Char* {
         return value_formatter_.parse(ctx);
     }
 
@@ -4690,15 +4690,15 @@ auto join(Range&& range, string_view sep)
     efp::String answer = efp_fmt::to_string(42);
   \endrst
  */
-template<typename T, FMT_ENABLE_IF(!std::is_integral<T>::value && !detail::has_format_as<T>::value)>
+template<typename T, EFP_FMT_ENABLE_IF(!std::is_integral<T>::value && !detail::has_format_as<T>::value)>
 inline auto to_string(const T& value) -> efp::String {
     auto buffer = memory_buffer();
     detail::write<char>(appender(buffer), value);
     return {buffer.data(), buffer.size()};
 }
 
-template<typename T, FMT_ENABLE_IF(std::is_integral<T>::value)>
-FMT_NODISCARD inline auto to_string(T value) -> efp::String {
+template<typename T, EFP_FMT_ENABLE_IF(std::is_integral<T>::value)>
+EFP_FMT_NODISCARD inline auto to_string(T value) -> efp::String {
     // The buffer should be large enough to store the number including the sign
     // or "false" for bool.
     constexpr int max_size = detail::digits10<T>() + 2;
@@ -4708,18 +4708,18 @@ FMT_NODISCARD inline auto to_string(T value) -> efp::String {
 }
 
 template<typename Char, size_t SIZE>
-FMT_NODISCARD auto to_string(const basic_memory_buffer<Char, SIZE>& buf) -> efp::BasicString<Char> {
+EFP_FMT_NODISCARD auto to_string(const basic_memory_buffer<Char, SIZE>& buf) -> efp::BasicString<Char> {
     auto size = buf.size();
     detail::assume(size < efp::BasicString<Char>().max_size());
     return efp::BasicString<Char>(buf.data(), size);
 }
 
-template<typename T, FMT_ENABLE_IF(!std::is_integral<T>::value && detail::has_format_as<T>::value)>
+template<typename T, EFP_FMT_ENABLE_IF(!std::is_integral<T>::value && detail::has_format_as<T>::value)>
 inline auto to_string(const T& value) -> efp::String {
     return to_string(format_as(value));
 }
 
-FMT_END_EXPORT
+EFP_FMT_END_EXPORT
 
 namespace detail {
 
@@ -4756,22 +4756,22 @@ void vformat_to(
             context.advance_to(write<Char>(context.out(), text));
         }
 
-        FMT_CONSTEXPR auto on_arg_id() -> int {
+        EFP_FMT_CONSTEXPR auto on_arg_id() -> int {
             return parse_context.next_arg_id();
         }
 
-        FMT_CONSTEXPR auto on_arg_id(int id) -> int {
+        EFP_FMT_CONSTEXPR auto on_arg_id(int id) -> int {
             return parse_context.check_arg_id(id), id;
         }
 
-        FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
+        EFP_FMT_CONSTEXPR auto on_arg_id(basic_string_view<Char> id) -> int {
             int arg_id = context.arg_id(id);
             if (arg_id < 0)
                 on_error("argument not found");
             return arg_id;
         }
 
-        FMT_INLINE void on_replacement_field(int id, const Char*) {
+        EFP_FMT_INLINE void on_replacement_field(int id, const Char*) {
             auto arg = get_arg(context, id);
             context.advance_to(visit_format_arg(
                 default_arg_formatter<Char> {context.out(), context.args(), context.locale()},
@@ -4809,21 +4809,21 @@ void vformat_to(
     detail::parse_format_string<false>(fmt, format_handler(out, fmt, args, loc));
 }
 
-FMT_BEGIN_EXPORT
+EFP_FMT_BEGIN_EXPORT
 
-#ifndef FMT_HEADER_ONLY
-extern template FMT_API void
+#ifndef EFP_FMT_HEADER_ONLY
+extern template EFP_FMT_API void
 vformat_to(buffer<char>&, string_view, typename vformat_args<>::type, locale_ref);
-extern template FMT_API auto thousands_sep_impl<char>(locale_ref) -> thousands_sep_result<char>;
-extern template FMT_API auto thousands_sep_impl<wchar_t>(locale_ref)
+extern template EFP_FMT_API auto thousands_sep_impl<char>(locale_ref) -> thousands_sep_result<char>;
+extern template EFP_FMT_API auto thousands_sep_impl<wchar_t>(locale_ref)
     -> thousands_sep_result<wchar_t>;
-extern template FMT_API auto decimal_point_impl(locale_ref) -> char;
-extern template FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
-#endif  // FMT_HEADER_ONLY
+extern template EFP_FMT_API auto decimal_point_impl(locale_ref) -> char;
+extern template EFP_FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
+#endif  // EFP_FMT_HEADER_ONLY
 
 }  // namespace detail
 
-#if FMT_USE_USER_DEFINED_LITERALS
+#if EFP_FMT_USE_USER_DEFINED_LITERALS
 inline namespace literals {
     /**
   \rst
@@ -4835,7 +4835,7 @@ inline namespace literals {
     efp_fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
-    #if FMT_USE_NONTYPE_TEMPLATE_ARGS
+    #if EFP_FMT_USE_NONTYPE_TEMPLATE_ARGS
 template<detail_exported::fixed_string Str>
 constexpr auto operator""_a() {
     using char_t = efp::CVRefRemoved<decltype(Str.data[0])>;
@@ -4847,14 +4847,14 @@ constexpr auto operator""_a(const char* s, size_t) -> detail::udl_arg<char> {
 }
     #endif
 }  // namespace literals
-#endif  // FMT_USE_USER_DEFINED_LITERALS
+#endif  // EFP_FMT_USE_USER_DEFINED_LITERALS
 
-template<typename Locale, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
+template<typename Locale, EFP_FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
 inline auto vformat(const Locale& loc, string_view fmt, format_args args) -> efp::String {
     return detail::vformat(loc, fmt, args);
 }
 
-template<typename Locale, typename... T, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
+template<typename Locale, typename... T, EFP_FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
 inline auto format(const Locale& loc, format_string<T...> fmt, T&&... args) -> efp::String {
     return efp_fmt::vformat(loc, string_view(fmt), efp_fmt::make_format_args(args...));
 }
@@ -4862,7 +4862,7 @@ inline auto format(const Locale& loc, format_string<T...> fmt, T&&... args) -> e
 template<
     typename OutputIt,
     typename Locale,
-    FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value&&
+    EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value&&
                       detail::is_locale<Locale>::value)>
 auto vformat_to(OutputIt out, const Locale& loc, string_view fmt, format_args args) -> OutputIt {
     using detail::get_buffer;
@@ -4875,26 +4875,26 @@ template<
     typename OutputIt,
     typename Locale,
     typename... T,
-    FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value&&
+    EFP_FMT_ENABLE_IF(detail::is_output_iterator<OutputIt, char>::value&&
                       detail::is_locale<Locale>::value)>
-FMT_INLINE auto format_to(OutputIt out, const Locale& loc, format_string<T...> fmt, T&&... args)
+EFP_FMT_INLINE auto format_to(OutputIt out, const Locale& loc, format_string<T...> fmt, T&&... args)
     -> OutputIt {
     return vformat_to(out, loc, fmt, efp_fmt::make_format_args(args...));
 }
 
-template<typename Locale, typename... T, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
-FMT_NODISCARD FMT_INLINE auto
+template<typename Locale, typename... T, EFP_FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
+EFP_FMT_NODISCARD EFP_FMT_INLINE auto
 formatted_size(const Locale& loc, format_string<T...> fmt, T&&... args) -> size_t {
     auto buf = detail::counting_buffer<>();
     detail::vformat_to<char>(buf, fmt, efp_fmt::make_format_args(args...), detail::locale_ref(loc));
     return buf.count();
 }
 
-FMT_END_EXPORT
+EFP_FMT_END_EXPORT
 
 template<typename T, typename Char>
 template<typename FormatContext>
-FMT_CONSTEXPR FMT_INLINE auto formatter<
+EFP_FMT_CONSTEXPR EFP_FMT_INLINE auto formatter<
     T,
     Char,
     efp::EnableIf<detail::type_constant<T, Char>::value != detail::type::custom_type>>::
@@ -4913,13 +4913,13 @@ FMT_CONSTEXPR FMT_INLINE auto formatter<
     return detail::write<Char>(ctx.out(), val, specs_, ctx.locale());
 }
 
-FMT_END_NAMESPACE
+EFP_FMT_END_NAMESPACE
 
-#ifdef FMT_HEADER_ONLY
-    #define FMT_FUNC inline
+#ifdef EFP_FMT_HEADER_ONLY
+    #define EFP_FMT_FUNC inline
     #include "format-inl.h"
 #else
-    #define FMT_FUNC
+    #define EFP_FMT_FUNC
 #endif
 
-#endif  // FMT_FORMAT_H_
+#endif  // EFP_FMT_FORMAT_H_

--- a/include/efp/fmt/format.h
+++ b/include/efp/fmt/format.h
@@ -133,7 +133,7 @@ FMT_END_NAMESPACE
             #define FMT_THROW(x) throw x
         #endif
     #else
-        #define FMT_THROW(x) ::fmt::detail::assert_fail(__FILE__, __LINE__, (x).what())
+        #define FMT_THROW(x) ::efp_fmt::detail::assert_fail(__FILE__, __LINE__, (x).what())
     #endif
 #endif
 
@@ -987,7 +987,7 @@ enum { inline_buffer_size = 500 };
 
   **Example**::
 
-     auto out = fmt::memory_buffer();
+     auto out = efp_fmt::memory_buffer();
      format_to(std::back_inserter(out), "The answer is {}.", 42);
 
   This will append the following output to the ``out`` object:
@@ -1075,7 +1075,7 @@ class basic_memory_buffer final: public detail::buffer<T> {
   public:
     /**
     \rst
-    Constructs a :class:`fmt::basic_memory_buffer` object moving the content
+    Constructs a :class:`efp_fmt::basic_memory_buffer` object moving the content
     of the other object to it.
     \endrst
    */
@@ -2038,8 +2038,8 @@ inline auto find_escape(const char* begin, const char* end) -> find_escape_resul
         struct FMT_VISIBILITY("hidden") FMT_COMPILE_STRING: base { \
             using char_type FMT_MAYBE_UNUSED = efp::CVRefRemoved<decltype(s[0])>; \
             FMT_MAYBE_UNUSED FMT_CONSTEXPR explicit \
-            operator fmt::basic_string_view<char_type>() const { \
-                return fmt::detail_exported::compile_string_to_view<char_type>(s); \
+            operator efp_fmt::basic_string_view<char_type>() const { \
+                return efp_fmt::detail_exported::compile_string_to_view<char_type>(s); \
             } \
         }; \
         return FMT_COMPILE_STRING(); \
@@ -2052,10 +2052,10 @@ inline auto find_escape(const char* begin, const char* end) -> find_escape_resul
   **Example**::
 
     // A compile-time error because 'd' is an invalid specifier for strings.
-    efp::String s = fmt::format(FMT_STRING("{:d}"), "foo");
+    efp::String s = efp_fmt::format(FMT_STRING("{:d}"), "foo");
   \endrst
  */
-#define FMT_STRING(s) FMT_STRING_IMPL(s, fmt::detail::compile_string, )
+#define FMT_STRING(s) FMT_STRING_IMPL(s, efp_fmt::detail::compile_string, )
 
 template<size_t width, typename Char, typename OutputIt>
 auto write_codepoint(OutputIt out, char prefix, uint32_t cp) -> OutputIt {
@@ -4210,7 +4210,7 @@ handle_dynamic_spec(int& value, arg_ref<typename Context::char_type> ref, Contex
 
 #if FMT_USE_USER_DEFINED_LITERALS
     #if FMT_USE_NONTYPE_TEMPLATE_ARGS
-template<typename T, typename Char, size_t N, fmt::detail_exported::fixed_string<Char, N> Str>
+template<typename T, typename Char, size_t N, efp_fmt::detail_exported::fixed_string<Char, N> Str>
 struct statically_named_arg: view {
     static constexpr auto name = Str.data;
 
@@ -4219,13 +4219,13 @@ struct statically_named_arg: view {
     statically_named_arg(const T& v) : value(v) {}
 };
 
-template<typename T, typename Char, size_t N, fmt::detail_exported::fixed_string<Char, N> Str>
+template<typename T, typename Char, size_t N, efp_fmt::detail_exported::fixed_string<Char, N> Str>
 struct is_named_arg<statically_named_arg<T, Char, N, Str>>: efp::True {};
 
-template<typename T, typename Char, size_t N, fmt::detail_exported::fixed_string<Char, N> Str>
+template<typename T, typename Char, size_t N, efp_fmt::detail_exported::fixed_string<Char, N> Str>
 struct is_statically_named_arg<statically_named_arg<T, Char, N, Str>>: efp::True {};
 
-template<typename Char, size_t N, fmt::detail_exported::fixed_string<Char, N> Str>
+template<typename Char, size_t N, efp_fmt::detail_exported::fixed_string<Char, N> Str>
 struct udl_arg {
     template<typename T>
     auto operator=(T&& value) const {
@@ -4269,7 +4269,7 @@ FMT_API auto vsystem_error(int error_code, string_view format_str, format_args a
 /**
   \rst
   Constructs :class:`std::system_error` with a message formatted with
-  ``fmt::format(fmt, args...)``.
+  ``efp_fmt::format(fmt, args...)``.
   *error_code* is a system error code as given by ``errno``.
 
   **Example**::
@@ -4280,12 +4280,12 @@ FMT_API auto vsystem_error(int error_code, string_view format_str, format_args a
     const char* filename = "madeup";
     std::FILE* file = std::fopen(filename, "r");
     if (!file)
-      throw fmt::system_error(errno, "cannot open file '{}'", filename);
+      throw efp_fmt::system_error(errno, "cannot open file '{}'", filename);
   \endrst
  */
 template<typename... T>
 auto system_error(int error_code, format_string<T...> fmt, T&&... args) -> std::system_error {
-    return vsystem_error(error_code, fmt, fmt::make_format_args(args...));
+    return vsystem_error(error_code, fmt, efp_fmt::make_format_args(args...));
 }
 
 /**
@@ -4422,7 +4422,7 @@ struct formatter<Char[N], Char>: formatter<basic_string_view<Char>, Char> {};
 
   **Example**::
 
-    auto s = fmt::format("{}", fmt::ptr(p));
+    auto s = efp_fmt::format("{}", efp_fmt::ptr(p));
   \endrst
  */
 template<typename T>
@@ -4448,7 +4448,7 @@ auto ptr(const std::shared_ptr<T>& p) -> const void* {
   **Example**::
 
     enum class color { red, green, blue };
-    auto s = fmt::format("{}", fmt::underlying(color::red));
+    auto s = efp_fmt::format("{}", efp_fmt::underlying(color::red));
   \endrst
  */
 template<typename Enum>
@@ -4508,7 +4508,7 @@ struct group_digits_view {
 
   **Example**::
 
-    fmt::print("{}", fmt::group_digits(12345));
+    efp_fmt::print("{}", efp_fmt::group_digits(12345));
     // Output: "12,345"
   \endrst
  */
@@ -4664,12 +4664,12 @@ auto join(It begin, Sentinel end, string_view sep) -> join_view<It, Sentinel> {
   **Example**::
 
     std::vector<int> v = {1, 2, 3};
-    fmt::print("{}", fmt::join(v, ", "));
+    efp_fmt::print("{}", efp_fmt::join(v, ", "));
     // Output: "1, 2, 3"
 
-  ``fmt::join`` applies passed format specifiers to the range elements::
+  ``efp_fmt::join`` applies passed format specifiers to the range elements::
 
-    fmt::print("{:02}", fmt::join(v, ", "));
+    efp_fmt::print("{:02}", efp_fmt::join(v, ", "));
     // Output: "01, 02, 03"
   \endrst
  */
@@ -4687,7 +4687,7 @@ auto join(Range&& range, string_view sep)
 
     #include <fmt/format.h>
 
-    efp::String answer = fmt::to_string(42);
+    efp::String answer = efp_fmt::to_string(42);
   \endrst
  */
 template<typename T, FMT_ENABLE_IF(!std::is_integral<T>::value && !detail::has_format_as<T>::value)>
@@ -4827,12 +4827,12 @@ extern template FMT_API auto decimal_point_impl(locale_ref) -> wchar_t;
 inline namespace literals {
     /**
   \rst
-  User-defined literal equivalent of :func:`fmt::arg`.
+  User-defined literal equivalent of :func:`efp_fmt::arg`.
 
   **Example**::
 
-    using namespace fmt::literals;
-    fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
+    using namespace efp_fmt::literals;
+    efp_fmt::print("Elapsed time: {s:.2f} seconds", "s"_a=1.23);
   \endrst
  */
     #if FMT_USE_NONTYPE_TEMPLATE_ARGS
@@ -4856,7 +4856,7 @@ inline auto vformat(const Locale& loc, string_view fmt, format_args args) -> efp
 
 template<typename Locale, typename... T, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
 inline auto format(const Locale& loc, format_string<T...> fmt, T&&... args) -> efp::String {
-    return fmt::vformat(loc, string_view(fmt), fmt::make_format_args(args...));
+    return efp_fmt::vformat(loc, string_view(fmt), efp_fmt::make_format_args(args...));
 }
 
 template<
@@ -4879,14 +4879,14 @@ template<
                       detail::is_locale<Locale>::value)>
 FMT_INLINE auto format_to(OutputIt out, const Locale& loc, format_string<T...> fmt, T&&... args)
     -> OutputIt {
-    return vformat_to(out, loc, fmt, fmt::make_format_args(args...));
+    return vformat_to(out, loc, fmt, efp_fmt::make_format_args(args...));
 }
 
 template<typename Locale, typename... T, FMT_ENABLE_IF(detail::is_locale<Locale>::value)>
 FMT_NODISCARD FMT_INLINE auto
 formatted_size(const Locale& loc, format_string<T...> fmt, T&&... args) -> size_t {
     auto buf = detail::counting_buffer<>();
-    detail::vformat_to<char>(buf, fmt, fmt::make_format_args(args...), detail::locale_ref(loc));
+    detail::vformat_to<char>(buf, fmt, efp_fmt::make_format_args(args...), detail::locale_ref(loc));
     return buf.count();
 }
 

--- a/include/efp/format.hpp
+++ b/include/efp/format.hpp
@@ -1,7 +1,7 @@
 #ifndef EFP_FORMAT_HPP_
 #define EFP_FORMAT_HPP_
 
-#define FMT_HEADER_ONLY
+#define EFP_FMT_HEADER_ONLY
 #include "efp/sequence.hpp"
 #include "efp/string.hpp"
 #include "efp/cyclic.hpp"

--- a/include/efp/format.hpp
+++ b/include/efp/format.hpp
@@ -2,55 +2,56 @@
 #define EFP_FORMAT_HPP_
 
 #define FMT_HEADER_ONLY
-#include "efp/fmt/core.h"
 #include "efp/sequence.hpp"
 #include "efp/string.hpp"
 #include "efp/cyclic.hpp"
 #include "efp/enum.hpp"
 
+#include "efp/fmt/core.h"
+
 namespace efp {
 
 template<typename... Args>
-using FormatString = fmt::format_string<Args...>;
+using FormatString = efp_fmt::format_string<Args...>;
 
 template<typename... Args>
 inline auto format(FormatString<Args...> fmt, Args&&... args) -> String {
-    return fmt::vformat(fmt, fmt::make_format_args(args...));
+    return efp_fmt::vformat(fmt, efp_fmt::make_format_args(args...));
 }
 
 template<typename... Args>
 inline void print(FormatString<Args...> fmt, Args&&... args) {
-    const auto& vargs = fmt::make_format_args(args...);
-    return fmt::detail::is_utf8() ? fmt::vprint(fmt, vargs)
-                                  : fmt::detail::vprint_mojibake(stdout, fmt, vargs);
+    const auto& vargs = efp_fmt::make_format_args(args...);
+    return efp_fmt::detail::is_utf8() ? efp_fmt::vprint(fmt, vargs)
+                                      : efp_fmt::detail::vprint_mojibake(stdout, fmt, vargs);
 }
 
 // todo Move to io.hpp
 // todo Need to make it use Maybe or Result rather than exceptions
 // template<typename... Args>
-// inline void print(std::FILE* f, fmt::format_string<Args...> fmt, Args&&... args) {
-//     const auto& vargs = fmt::make_format_args(args...);
-//     return fmt::detail::is_utf8() ? fmt::vprint(f, fmt, vargs)
-//                                   : fmt::detail::vprint_mojibake(f, fmt, vargs);
+// inline void print(std::FILE* f, efp_fmt::format_string<Args...> fmt, Args&&... args) {
+//     const auto& vargs = efp_fmt::make_format_args(args...);
+//     return efp_fmt::detail::is_utf8() ? efp_fmt::vprint(f, fmt, vargs)
+//                                   : efp_fmt::detail::vprint_mojibake(f, fmt, vargs);
 // }
 
 template<typename... Args>
 inline void println(FormatString<Args...> fmt, Args&&... args) {
-    return fmt::println(stdout, fmt, efp::forward<Args>(args)...);
+    return efp_fmt::println(stdout, fmt, efp::forward<Args>(args)...);
 }
 
 // todo Move to io.hpp
 // todo Need to make it use Maybe or Result rather than exceptions
 // template<typename... Args>
-// inline void println(std::FILE* f, fmt::format_string<Args...> fmt, Args&&... args) {
-//     return fmt::print(f, "{}\n", fmt::format(fmt, efp::forward<Args>(args)...));
+// inline void println(std::FILE* f, efp_fmt::format_string<Args...> fmt, Args&&... args) {
+//     return efp_fmt::print(f, "{}\n", efp_fmt::format(fmt, efp::forward<Args>(args)...));
 // }
 
 }  // namespace efp
 
-// Specialize fmt::formatter for efp::Array
+// Specialize efp_fmt::formatter for efp::Array
 template<typename T, size_t ct_size>
-struct fmt::formatter<efp::Array<T, ct_size>> {
+struct efp_fmt::formatter<efp::Array<T, ct_size>> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
         return ctx.begin();
@@ -58,13 +59,13 @@ struct fmt::formatter<efp::Array<T, ct_size>> {
 
     template<typename FormatContext>
     auto format(const efp::Array<T, ct_size>& arr, FormatContext& ctx) -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "[{}]", fmt::join(arr.begin(), arr.end(), ", "));
+        return efp_fmt::format_to(ctx.out(), "[{}]", efp_fmt::join(arr.begin(), arr.end(), ", "));
     }
 };
 
-// Specialize fmt::formatter for efp::ArrVec
+// Specialize efp_fmt::formatter for efp::ArrVec
 template<typename T, size_t ct_cap>
-struct fmt::formatter<efp::ArrVec<T, ct_cap>> {
+struct efp_fmt::formatter<efp::ArrVec<T, ct_cap>> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
         return ctx.begin();
@@ -73,13 +74,17 @@ struct fmt::formatter<efp::ArrVec<T, ct_cap>> {
     template<typename FormatContext>
     auto format(const efp::ArrVec<T, ct_cap>& arrvec, FormatContext& ctx)
         -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "[{}]", fmt::join(arrvec.begin(), arrvec.end(), ", "));
+        return efp_fmt::format_to(
+            ctx.out(),
+            "[{}]",
+            efp_fmt::join(arrvec.begin(), arrvec.end(), ", ")
+        );
     }
 };
 
-// Specialize fmt::formatter for efp::Vector
+// Specialize efp_fmt::formatter for efp::Vector
 template<typename T, typename Allocator, typename Traits>
-struct fmt::formatter<efp::Vector<T, Allocator, Traits>> {
+struct efp_fmt::formatter<efp::Vector<T, Allocator, Traits>> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
         return ctx.begin();
@@ -88,13 +93,13 @@ struct fmt::formatter<efp::Vector<T, Allocator, Traits>> {
     template<typename FormatContext>
     auto format(const efp::Vector<T, Allocator, Traits>& vec, FormatContext& ctx)
         -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "[{}]", fmt::join(vec.begin(), vec.end(), ", "));
+        return efp_fmt::format_to(ctx.out(), "[{}]", efp_fmt::join(vec.begin(), vec.end(), ", "));
     }
 };
 
-// Sepecialize fmt::formatter for efp::Vcb
+// Sepecialize efp_fmt::formatter for efp::Vcb
 template<typename T, size_t ct_size>
-struct fmt::formatter<efp::Vcb<T, ct_size>> {
+struct efp_fmt::formatter<efp::Vcb<T, ct_size>> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
         return ctx.begin();
@@ -102,13 +107,13 @@ struct fmt::formatter<efp::Vcb<T, ct_size>> {
 
     template<typename FormatContext>
     auto format(const efp::Vcb<T, ct_size>& vcb, FormatContext& ctx) -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "[{}]", fmt::join(vcb.begin(), vcb.end(), ", "));
+        return efp_fmt::format_to(ctx.out(), "[{}]", efp_fmt::join(vcb.begin(), vcb.end(), ", "));
     }
 };
 
-// Specialize fmt::formatter for efp::Vcq
+// Specialize efp_fmt::formatter for efp::Vcq
 template<typename T, size_t ct_cap>
-struct fmt::formatter<efp::Vcq<T, ct_cap>> {
+struct efp_fmt::formatter<efp::Vcq<T, ct_cap>> {
     template<typename ParseContext>
     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
         return ctx.begin();
@@ -116,14 +121,14 @@ struct fmt::formatter<efp::Vcq<T, ct_cap>> {
 
     template<typename FormatContext>
     auto format(const efp::Vcq<T, ct_cap>& vcq, FormatContext& ctx) -> format_context::iterator {
-        return fmt::format_to(ctx.out(), "[{}]", fmt::join(vcq.begin(), vcq.end(), ", "));
+        return efp_fmt::format_to(ctx.out(), "[{}]", efp_fmt::join(vcq.begin(), vcq.end(), ", "));
     }
 };
 
 // todo enum support
-// Specialize fmt::formatter for efp::Enum
+// Specialize efp_fmt::formatter for efp::Enum
 // template<typename... As>
-// struct fmt::formatter<efp::Enum<As...>> {
+// struct efp_fmt::formatter<efp::Enum<As...>> {
 //     template<typename ParseContext>
 //     constexpr auto parse(ParseContext& ctx) const -> format_parse_context::iterator {
 //         return ctx.begin();
@@ -131,7 +136,7 @@ struct fmt::formatter<efp::Vcq<T, ct_cap>> {
 
 //     template<typename FormatContext>
 //     auto format(const efp::Enum<As...>& enm, FormatContext& ctx) -> format_context::iterator {
-//         return fmt::format_to(ctx.out(), "{}", enm.to_string());
+//         return efp_fmt::format_to(ctx.out(), "{}", enm.to_string());
 //     }
 // };
 

--- a/include/efp/sequence.hpp
+++ b/include/efp/sequence.hpp
@@ -1363,24 +1363,24 @@ constexpr auto data(VectorView<A>& as) -> const A* {
 
 #if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
 
-template<typename A>
-auto operator<<(std::ostream& os, const A& seq) -> EnableIf<
-    IsSequence<A>::value && !detail::IsCharType<Element<A>>::value
-        && !IsSame<A, std::string>::value,
-    std::ostream&> {
-    static_assert(IsSequence<A>(), "Argument should be an instance of Sequence trait.");
+// template<typename A>
+// auto operator<<(std::ostream& os, const A& seq) -> EnableIf<
+//     IsSequence<A>::value && !detail::IsCharType<Element<A>>::value
+//         && !IsSame<A, std::string>::value,
+//     std::ostream&> {
+//     static_assert(IsSequence<A>(), "Argument should be an instance of Sequence trait.");
 
-    // ? Interesting. Automatically consider it as VectorStream?
-    os << "{ ";
-    for (size_t i = 0; i < seq.size(); ++i) {
-        os << seq[i];
-        if (i != seq.size() - 1) {
-            os << ", ";
-        }
-    }
-    os << " }";
-    return os;
-}
+//     // ? Interesting. Automatically consider it as VectorStream?
+//     os << "{ ";
+//     for (size_t i = 0; i < seq.size(); ++i) {
+//         os << seq[i];
+//         if (i != seq.size() - 1) {
+//             os << ", ";
+//         }
+//     }
+//     os << " }";
+//     return os;
+// }
 
 #endif
 

--- a/include/efp/string.hpp
+++ b/include/efp/string.hpp
@@ -353,18 +353,18 @@ using U8StringView = BasicStringView<char8_t>;
 
 #if defined(__STDC_HOSTED__) && __STDC_HOSTED__ == 1
 
-template<typename A>
-auto operator<<(std::ostream& os, const A& seq) -> EnableIf<
-    IsSequence<A>::value && detail::IsCharType<Element<A>>::value && !IsSame<A, std::string>::value,
-    std::ostream&> {
-    static_assert(IsSequence<A>(), "Argument should be an instance of Sequence trait.");
+// template<typename A>
+// auto operator<<(std::ostream& os, const A& seq) -> EnableIf<
+//     IsSequence<A>::value && detail::IsCharType<Element<A>>::value && !IsSame<A, std::string>::value,
+//     std::ostream&> {
+//     static_assert(IsSequence<A>(), "Argument should be an instance of Sequence trait.");
 
-    for (const auto& elem : seq) {
-        os << elem;
-    }
+//     for (const auto& elem : seq) {
+//         os << elem;
+//     }
 
-    return os;
-}
+//     return os;
+// }
 
 #endif
 

--- a/include/efp/string.hpp
+++ b/include/efp/string.hpp
@@ -31,14 +31,14 @@ public:
         Base::_size = Traits::length(c_str);
         Base::_capacity = Base::_size + 1;
         Base::_data = Base::_allocator.allocate(Base::_capacity);
-        efp::memcpy(Base::_data, c_str, Base::_size * sizeof(Char));
+        _memcpy(Base::_data, c_str, Base::_size * sizeof(Char));
     }
 
     Vector(const Char* s, size_t count, const Allocator& alloc = Allocator()) {
         Base::_size = count;
         Base::_capacity = Base::_size + 1;
         Base::_data = Base::_allocator.allocate(Base::_capacity);
-        efp::memcpy(Base::_data, s, Base::_size * sizeof(Char));
+        _memcpy(Base::_data, s, Base::_size * sizeof(Char));
     }
 
     Vector(size_t size, Char c) {
@@ -220,7 +220,7 @@ public:
             count = Base::_size - pos;
         }
 
-        efp::memcpy(dest, Base::_data + pos, count * sizeof(Char));
+        _memcpy(dest, Base::_data + pos, count * sizeof(Char));
         return count;
     }
 

--- a/test/efp/CMakeLists.txt
+++ b/test/efp/CMakeLists.txt
@@ -17,10 +17,10 @@ endif()
 include(Catch)
 enable_testing()
 
-add_executable(all_test test.cpp)
-target_link_libraries(all_test
+add_executable(efp_test test.cpp)
+target_link_libraries(efp_test
     PRIVATE
     Catch2::Catch2WithMain
     efp)
 
-catch_discover_tests(all_test)
+catch_discover_tests(efp_test)

--- a/test/efp/CMakeLists.txt
+++ b/test/efp/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(CTest)
 
+include(FetchContent)
+
 find_package(Catch2 QUIET)
 
 if(NOT Catch2_FOUND)


### PR DESCRIPTION
- Resolve possible name conflict issue for `efp::memcpy`.
    - Now use `efp::_memcpy` internally.
- Resolve possible macro interferance issues with the `fmt` library.